### PR TITLE
Move panel titles into top border

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/justincampbell/revise/internal/git"
 )
@@ -74,13 +75,6 @@ func (m *diffViewModel) buildLines() {
 		m.lines = append(m.lines, s)
 		m.lineRefs = append(m.lineRefs, ref)
 	}
-
-	header := m.file.Path
-	if m.file.OldPath != "" {
-		header = m.file.OldPath + " → " + m.file.Path
-	}
-	add(fileStyle.Render(header), nil)
-	add("", nil)
 
 	for _, hunk := range m.file.Hunks {
 		add(hunkStyle.Render(hunk.Header), nil)
@@ -417,5 +411,52 @@ func (m diffViewModel) render(focused bool) string {
 	if focused {
 		style = focusedBorder
 	}
-	return style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(content)
+	rendered := style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(content)
+
+	title := ""
+	if m.file != nil {
+		title = " " + m.file.Path + " "
+		if m.file.OldPath != "" {
+			title = " " + m.file.OldPath + " → " + m.file.Path + " "
+		}
+	}
+	if title != "" {
+		rendered = setBorderTitle(rendered, title, focused)
+	}
+	return rendered
+}
+
+// setBorderTitle overlays a styled title onto the top border of a lipgloss-rendered box.
+// Lipgloss v1.1.0 doesn't support border titles natively, so we reconstruct
+// the top border line: ╭ + title + remaining ─ chars + ╮.
+func setBorderTitle(rendered, title string, focused bool) string {
+	nl := strings.IndexByte(rendered, '\n')
+	if nl < 0 {
+		return rendered
+	}
+	topLine := rendered[:nl]
+	rest := rendered[nl:]
+
+	borderColor := colorBorder
+	if focused {
+		borderColor = colorCyan
+	}
+	bc := lipgloss.NewStyle().Foreground(borderColor)
+
+	totalWidth := ansi.StringWidth(topLine)
+	titleRendered := fileStyle.Render(title)
+	titleWidth := ansi.StringWidth(titleRendered)
+
+	// Need at least room for ╭ + title + ╮
+	if titleWidth+2 > totalWidth {
+		return rendered
+	}
+
+	fillWidth := totalWidth - 1 - titleWidth - 1 // minus ╭ and ╮
+	if fillWidth < 0 {
+		fillWidth = 0
+	}
+
+	newTop := bc.Render("╭") + titleRendered + bc.Render(strings.Repeat("─", fillWidth)) + bc.Render("╮")
+	return newTop + rest
 }

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -158,11 +158,17 @@ func TestDiffViewCursorSkipsNilRefLines(t *testing.T) {
 	assert.Equal(t, 3, m.cursor)
 }
 
-func TestCursorRef_OnHeaderLine(t *testing.T) {
+func TestCursorRef_OnHunkHeaderLine(t *testing.T) {
 	m := newDiffViewModel()
-	m.file = &git.FileDiff{Path: "foo.go"}
+	m.file = &git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hello", NewNum: 1}},
+		}},
+	}
 	m.buildLines()
-	m.cursor = 0 // file header line (nil ref)
+	m.cursor = 0 // hunk header line (nil ref)
 	assert.Nil(t, m.cursorRef())
 }
 
@@ -178,8 +184,8 @@ func TestCursorRef_OnCodeLine(t *testing.T) {
 		}},
 	}
 	m.buildLines()
-	// lines: [0: header, 1: blank, 2: hunk, 3: code, 4: blank]
-	m.cursor = 3
+	// lines: [0: hunk, 1: code, 2: blank]
+	m.cursor = 1
 	ref := m.cursorRef()
 	assert.NotNil(t, ref)
 	key := ref.commentKey("foo.go")
@@ -213,6 +219,53 @@ func TestLineRef_CommentKey_NoCollision_RemovedAndAdded(t *testing.T) {
 	removed := lineRef{oldNum: 5, lineType: git.LineRemoved}
 	added := lineRef{newNum: 5, lineType: git.LineAdded}
 	assert.NotEqual(t, removed.commentKey("f"), added.commentKey("f"))
+}
+
+func TestBuildLines_NoFileHeader(t *testing.T) {
+	m := newDiffViewModel()
+	m.file = &git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hello", NewNum: 1}},
+		}},
+	}
+	m.buildLines()
+	// First line should be the hunk header, not the filename.
+	assert.Contains(t, m.lines[0], "@@ -1,1 +1,1 @@")
+}
+
+func TestDiffView_TitleInBorder(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 40
+	m.height = 10
+	m.file = &git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hello", NewNum: 1}},
+		}},
+	}
+	m.buildLines()
+	rendered := m.render(true)
+	assert.Contains(t, rendered, "foo.go")
+}
+
+func TestDiffView_RenamedTitleInBorder(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 60
+	m.height = 10
+	m.file = &git.FileDiff{
+		Path:    "new.go",
+		OldPath: "old.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hello", NewNum: 1}},
+		}},
+	}
+	m.buildLines()
+	rendered := m.render(true)
+	assert.Contains(t, rendered, "old.go → new.go")
 }
 
 func TestClickToAbsIdx_NoInputBox(t *testing.T) {

--- a/internal/ui/filelist.go
+++ b/internal/ui/filelist.go
@@ -48,7 +48,7 @@ func (m *fileListModel) ensureVisible() {
 }
 
 func (m *fileListModel) viewHeight() int {
-	// Account for header line
+	// Account for top/bottom border
 	h := m.height - 2
 	if h < 1 {
 		h = 1
@@ -69,11 +69,6 @@ func (m fileListModel) render(focused bool) string {
 	}
 
 	var b strings.Builder
-
-	// Header
-	header := fmt.Sprintf(" Files (%d/%d)", m.cursor+1, len(m.files))
-	b.WriteString(fileStyle.Render(header))
-	b.WriteString("\n")
 
 	viewHeight := m.viewHeight()
 	end := m.offset + viewHeight
@@ -108,7 +103,11 @@ func (m fileListModel) render(focused bool) string {
 	if focused {
 		style = focusedBorder
 	}
-	return style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(b.String())
+	rendered := style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(b.String())
+
+	title := fmt.Sprintf(" Files (%d/%d) ", m.cursor+1, len(m.files))
+	rendered = setBorderTitle(rendered, title, focused)
+	return rendered
 }
 
 func statusIndicator(s git.FileStatus) string {

--- a/internal/ui/filelist_test.go
+++ b/internal/ui/filelist_test.go
@@ -84,3 +84,11 @@ func TestTruncate_ZeroMax(t *testing.T) {
 func TestTruncate_VerySmallMax(t *testing.T) {
 	assert.Equal(t, "ab", truncate("abcdef", 2))
 }
+
+func TestFileList_TitleInBorder(t *testing.T) {
+	m := newFileListModel(makeFiles("a.go", "b.go", "c.go"))
+	m.width = 30
+	m.height = 10
+	rendered := m.render(true)
+	assert.Contains(t, rendered, "Files (1/3)")
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -154,9 +154,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case tea.MouseButtonLeft:
 			if !m.mouseFocusDiff(msg) {
-				// border (1) + header (1) = 2 lines before file entries
+				// border (1) = 1 line before file entries
 				if !m.commentInputActive {
-					idx := msg.Y - 2 + m.fileList.offset
+					idx := msg.Y - 1 + m.fileList.offset
 					if idx >= 0 && idx < len(m.fileList.files) {
 						m.fileList.cursor = idx
 						m.syncSelectedFile()


### PR DESCRIPTION
## Summary
- Renders panel titles ("Files (1/3)" and filename) in the top border instead of as content lines, saving vertical space
- Adds `setBorderTitle` helper that reconstructs the top border line with styled title text (avoids ANSI escape corruption from rune-level replacement)
- Updates mouse click offset (Y-2 → Y-1) since file list no longer has a header row

## Test plan
- [x] `TestBuildLines_NoFileHeader` — first line is hunk header, not filename
- [x] `TestDiffView_TitleInBorder` — filename appears in rendered border
- [x] `TestDiffView_RenamedTitleInBorder` — rename format in border
- [x] `TestFileList_TitleInBorder` — "Files (1/3)" in rendered border
- [x] `TestCursorRef_OnHunkHeaderLine` — updated from old header test
- [x] `TestCursorRef_OnCodeLine` — cursor index shifted (was 3, now 1)