### PR TITLE
Hide diff cursor when pane is not focused

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -399,8 +399,9 @@ func hunkContext(header string) string {
 }
 
 // linePrefix returns the 1-character cursor indicator for a display line.
-func (m diffViewModel) linePrefix(absIdx int) string {
-	if m.file != nil && absIdx == m.cursor {
+// The cursor is only shown when the diff pane is focused.
+func (m diffViewModel) linePrefix(absIdx int, focused bool) string {
+	if focused && m.file != nil && absIdx == m.cursor {
 		return cursorStyle.Render("▶")
 	}
 	return " "
@@ -421,7 +422,7 @@ func (m diffViewModel) render(focused bool) string {
 		if ansi.StringWidth(line) > maxWidth {
 			line = ansi.Truncate(line, maxWidth, "")
 		}
-		return m.linePrefix(absIdx) + line
+		return m.linePrefix(absIdx, focused) + line
 	}
 
 	var renderedLines []string

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -196,15 +196,23 @@ func TestCursorRef_OnCodeLine(t *testing.T) {
 func TestLinePrefix_NoFileSelected(t *testing.T) {
 	m := newDiffViewModel()
 	// m.file is nil — no file selected
-	assert.Equal(t, " ", m.linePrefix(0))
+	assert.Equal(t, " ", m.linePrefix(0, true))
 }
 
-func TestLinePrefix_WithFileSelected(t *testing.T) {
+func TestLinePrefix_WithFileSelected_Focused(t *testing.T) {
 	m := newDiffViewModel()
 	m.file = &git.FileDiff{Path: "foo.go"}
 	m.cursor = 2
-	assert.Equal(t, " ", m.linePrefix(0))
-	assert.Contains(t, m.linePrefix(2), "▶")
+	assert.Equal(t, " ", m.linePrefix(0, true))
+	assert.Contains(t, m.linePrefix(2, true), "▶")
+}
+
+func TestLinePrefix_WithFileSelected_NotFocused(t *testing.T) {
+	m := newDiffViewModel()
+	m.file = &git.FileDiff{Path: "foo.go"}
+	m.cursor = 2
+	assert.Equal(t, " ", m.linePrefix(0, false))
+	assert.Equal(t, " ", m.linePrefix(2, false)) // cursor hidden when not focused
 }
 
 func TestLineRef_CommentKey_Added(t *testing.T) {


### PR DESCRIPTION
## Summary
- Hide the diff cursor when the diff pane is not focused (#28) — the cursor indicator was visible even when the file list had focus, which was misleading since you can't interact with it from there

## Test plan
- [x] Existing linePrefix tests updated; new test added for unfocused state
- [x] make test passes
- [ ] Manually verify: cursor disappears when file list is focused, reappears when diff is focused

Closes #28

Generated with [Claude Code](https://claude.com/claude-code)