### PR TITLE
Stage, unstage, and discard hunks and files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,11 @@ internal/
   git/
     types.go                   # Diff, FileDiff, Hunk, Line types
     diff.go                    # GetDiff, branch detection, merge-base logic
+    apply.go                   # stage/unstage/discard hunks via git apply
     parse.go                   # unified diff parser
     untracked.go               # untracked file detection
     parse_test.go              # parser unit tests
+    apply_test.go              # stage/unstage/discard integration tests
     diff_test.go               # mergeFileDiffs unit tests
     diff_integration_test.go   # GetDiff/StagedDiff/etc integration tests (real git repos)
     testhelper_test.go         # TestRepo helper for integration tests
@@ -154,6 +156,9 @@ Bubbletea maps the Escape key to the string `"esc"` (not `"escape"`) — use `ca
 | `Fn+↑` | Page up |
 | `c` / `Enter` | Add/edit comment on current diff line |
 | `d` | Delete comment on current diff line |
+| `s` / `S` | Stage hunk / file (file list: `s` stages file) |
+| `u` / `U` | Unstage hunk / file (file list: `u` unstages file) |
+| `D` | Discard hunk / file (with `y` confirmation) |
 
 ### Mouse Support
 

--- a/internal/git/apply.go
+++ b/internal/git/apply.go
@@ -1,0 +1,124 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// HunkPatch reconstructs a unified diff patch for a single hunk,
+// suitable for piping to `git apply`.
+func HunkPatch(path string, status FileStatus, h Hunk) string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("diff --git a/%s b/%s\n", path, path))
+
+	switch status {
+	case StatusAdded:
+		b.WriteString("--- /dev/null\n")
+		b.WriteString(fmt.Sprintf("+++ b/%s\n", path))
+	case StatusDeleted:
+		b.WriteString(fmt.Sprintf("--- a/%s\n", path))
+		b.WriteString("+++ /dev/null\n")
+	default:
+		b.WriteString(fmt.Sprintf("--- a/%s\n", path))
+		b.WriteString(fmt.Sprintf("+++ b/%s\n", path))
+	}
+
+	b.WriteString(fmt.Sprintf("@@ -%d,%d +%d,%d @@\n", h.OldStart, h.OldCount, h.NewStart, h.NewCount))
+
+	for _, line := range h.Lines {
+		switch line.Type {
+		case LineAdded:
+			b.WriteString("+" + line.Content + "\n")
+		case LineRemoved:
+			b.WriteString("-" + line.Content + "\n")
+		case LineContext:
+			b.WriteString(" " + line.Content + "\n")
+		}
+	}
+
+	return b.String()
+}
+
+// StageHunk stages a single hunk by applying the patch to the index.
+// Untracked files don't exist in the index, so git apply --cached fails;
+// fall back to git add for those.
+func StageHunk(path string, status FileStatus, h Hunk) error {
+	if status == StatusUntracked {
+		return StageFile(path)
+	}
+	patch := HunkPatch(path, status, h)
+	return gitApply(patch, "--cached")
+}
+
+// UnstageHunk unstages a single hunk by reverse-applying the patch from the index.
+func UnstageHunk(path string, status FileStatus, h Hunk) error {
+	patch := HunkPatch(path, status, h)
+	return gitApply(patch, "-R", "--cached")
+}
+
+// DiscardHunk discards a hunk by reverting it from the working tree.
+// For staged hunks, it first unstages, then reverts the working tree.
+func DiscardHunk(path string, status FileStatus, h Hunk) error {
+	patch := HunkPatch(path, status, h)
+	if h.Source == SourceStaged {
+		if err := gitApply(patch, "-R", "--cached"); err != nil {
+			return err
+		}
+	}
+	return gitApply(patch, "-R")
+}
+
+// StageFile stages an entire file.
+func StageFile(path string) error {
+	out, err := exec.Command("git", "add", "--", path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git add: %s\n%s", err, string(out))
+	}
+	return nil
+}
+
+// UnstageFile unstages an entire file (keeps working tree changes).
+func UnstageFile(path string) error {
+	out, err := exec.Command("git", "reset", "HEAD", "--", path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git reset: %s\n%s", err, string(out))
+	}
+	return nil
+}
+
+// DiscardFile discards all changes to a file.
+// For untracked files, removes the file.
+// If staged is true, unstages first, then reverts the working tree.
+func DiscardFile(path string, status FileStatus, staged bool) error {
+	if status == StatusUntracked {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove %s: %w", path, err)
+		}
+		return nil
+	}
+	if staged {
+		if err := UnstageFile(path); err != nil {
+			return err
+		}
+	}
+	out, err := exec.Command("git", "checkout", "--", path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git checkout: %s\n%s", err, string(out))
+	}
+	return nil
+}
+
+// gitApply runs git apply with the given flags, piping patch to stdin.
+func gitApply(patch string, flags ...string) error {
+	args := append([]string{"apply"}, flags...)
+	cmd := exec.Command("git", args...)
+	cmd.Stdin = strings.NewReader(patch)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git apply: %s\n%s", err, string(out))
+	}
+	return nil
+}

--- a/internal/git/apply_test.go
+++ b/internal/git/apply_test.go
@@ -1,0 +1,381 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHunkPatch(t *testing.T) {
+	hunk := Hunk{
+		OldStart: 1,
+		OldCount: 3,
+		NewStart: 1,
+		NewCount: 4,
+		Header:   "@@ -1,3 +1,4 @@ func main()",
+		Lines: []Line{
+			{Type: LineContext, Content: "package main", OldNum: 1, NewNum: 1},
+			{Type: LineAdded, Content: "", NewNum: 2},
+			{Type: LineContext, Content: "func base() {}", OldNum: 2, NewNum: 3},
+			{Type: LineContext, Content: "", OldNum: 3, NewNum: 4},
+		},
+	}
+
+	patch := HunkPatch("base.go", StatusModified, hunk)
+
+	if !strings.HasPrefix(patch, "diff --git a/base.go b/base.go\n") {
+		t.Errorf("expected diff header, got:\n%s", patch)
+	}
+	if !strings.Contains(patch, "--- a/base.go\n") {
+		t.Errorf("expected --- a/base.go, got:\n%s", patch)
+	}
+	if !strings.Contains(patch, "+++ b/base.go\n") {
+		t.Errorf("expected +++ b/base.go, got:\n%s", patch)
+	}
+	if !strings.Contains(patch, "@@ -1,3 +1,4 @@\n") {
+		t.Errorf("expected hunk header, got:\n%s", patch)
+	}
+	if !strings.Contains(patch, "+\n") {
+		t.Errorf("expected added line, got:\n%s", patch)
+	}
+}
+
+func TestHunkPatch_newFile(t *testing.T) {
+	hunk := Hunk{
+		OldStart: 0,
+		OldCount: 0,
+		NewStart: 1,
+		NewCount: 1,
+		Header:   "@@ -0,0 +1 @@",
+		Lines: []Line{
+			{Type: LineAdded, Content: "new content", NewNum: 1},
+		},
+	}
+
+	patch := HunkPatch("new.go", StatusAdded, hunk)
+
+	if !strings.Contains(patch, "--- /dev/null\n") {
+		t.Errorf("expected --- /dev/null for new file, got:\n%s", patch)
+	}
+	if !strings.Contains(patch, "+++ b/new.go\n") {
+		t.Errorf("expected +++ b/new.go, got:\n%s", patch)
+	}
+}
+
+func TestHunkPatch_deletedFile(t *testing.T) {
+	hunk := Hunk{
+		OldStart: 1,
+		OldCount: 1,
+		NewStart: 0,
+		NewCount: 0,
+		Header:   "@@ -1 +0,0 @@",
+		Lines: []Line{
+			{Type: LineRemoved, Content: "old content", OldNum: 1},
+		},
+	}
+
+	patch := HunkPatch("old.go", StatusDeleted, hunk)
+
+	if !strings.Contains(patch, "--- a/old.go\n") {
+		t.Errorf("expected --- a/old.go, got:\n%s", patch)
+	}
+	if !strings.Contains(patch, "+++ /dev/null\n") {
+		t.Errorf("expected +++ /dev/null for deleted file, got:\n%s", patch)
+	}
+}
+
+func TestStageHunk(t *testing.T) {
+	r := baseRepo(t)
+
+	// Create unstaged changes
+	r.WriteFile("base.go", "package main\n\n// added line\nfunc base() {}\n")
+
+	// Get the unstaged diff to find the hunk
+	raw, err := UnstagedDiff(DefaultContextLines)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := Parse(raw)
+	if len(diff.Files) == 0 {
+		t.Fatal("expected unstaged changes")
+	}
+	file := diff.Files[0]
+	if len(file.Hunks) == 0 {
+		t.Fatal("expected at least one hunk")
+	}
+
+	// Stage the hunk
+	err = StageHunk(file.Path, file.Status, file.Hunks[0])
+	if err != nil {
+		t.Fatalf("StageHunk: %v", err)
+	}
+
+	// Verify: should now be staged
+	staged := r.StagedDiffRaw()
+	if !strings.Contains(staged, "added line") {
+		t.Errorf("expected staged diff to contain 'added line', got:\n%s", staged)
+	}
+
+	// Verify: should have no unstaged changes
+	unstaged := r.UnstagedDiffRaw()
+	if strings.Contains(unstaged, "added line") {
+		t.Errorf("expected no unstaged changes for 'added line', got:\n%s", unstaged)
+	}
+}
+
+func TestUnstageHunk(t *testing.T) {
+	r := baseRepo(t)
+
+	// Create and stage changes
+	r.WriteFile("base.go", "package main\n\n// staged line\nfunc base() {}\n")
+	r.Add("base.go")
+
+	// Get the staged diff to find the hunk
+	raw, err := StagedDiff(DefaultContextLines)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := Parse(raw)
+	if len(diff.Files) == 0 {
+		t.Fatal("expected staged changes")
+	}
+	file := diff.Files[0]
+	if len(file.Hunks) == 0 {
+		t.Fatal("expected at least one hunk")
+	}
+
+	// Unstage the hunk
+	err = UnstageHunk(file.Path, file.Status, file.Hunks[0])
+	if err != nil {
+		t.Fatalf("UnstageHunk: %v", err)
+	}
+
+	// Verify: should no longer be staged
+	staged := r.StagedDiffRaw()
+	if strings.Contains(staged, "staged line") {
+		t.Errorf("expected no staged changes, got:\n%s", staged)
+	}
+
+	// Verify: should now be unstaged
+	unstaged := r.UnstagedDiffRaw()
+	if !strings.Contains(unstaged, "staged line") {
+		t.Errorf("expected unstaged diff to contain 'staged line', got:\n%s", unstaged)
+	}
+}
+
+func TestStageHunk_untrackedFile(t *testing.T) {
+	r := baseRepo(t)
+
+	// Create an untracked file
+	r.WriteFile("newfile.go", "package main\n\nfunc newFunc() {}\n")
+
+	// Simulate the synthetic hunk that UntrackedFiles() would produce
+	hunk := Hunk{
+		OldStart: 0,
+		OldCount: 0,
+		NewStart: 1,
+		NewCount: 3,
+		Header:   "@@ -0,0 +1,3 @@",
+		Source:   SourceUnstaged,
+		Lines: []Line{
+			{Type: LineAdded, Content: "package main", NewNum: 1},
+			{Type: LineAdded, Content: "", NewNum: 2},
+			{Type: LineAdded, Content: "func newFunc() {}", NewNum: 3},
+		},
+	}
+
+	err := StageHunk("newfile.go", StatusUntracked, hunk)
+	if err != nil {
+		t.Fatalf("StageHunk on untracked file: %v", err)
+	}
+
+	// Verify: should now be staged
+	staged := r.StagedDiffRaw()
+	if !strings.Contains(staged, "newFunc") {
+		t.Errorf("expected staged diff to contain 'newFunc', got:\n%s", staged)
+	}
+
+	// Verify: should no longer appear as untracked
+	status := r.StatusPorcelain()
+	if strings.Contains(status, "??") {
+		t.Errorf("expected file to no longer be untracked, got:\n%s", status)
+	}
+}
+
+func TestStageFile(t *testing.T) {
+	r := baseRepo(t)
+
+	// Create unstaged changes
+	r.WriteFile("base.go", "package main\n\n// stage me\nfunc base() {}\n")
+
+	err := StageFile("base.go")
+	if err != nil {
+		t.Fatalf("StageFile: %v", err)
+	}
+
+	staged := r.StagedDiffRaw()
+	if !strings.Contains(staged, "stage me") {
+		t.Errorf("expected staged diff to contain 'stage me', got:\n%s", staged)
+	}
+	unstaged := r.UnstagedDiffRaw()
+	if strings.Contains(unstaged, "stage me") {
+		t.Errorf("expected no unstaged changes, got:\n%s", unstaged)
+	}
+}
+
+func TestUnstageFile(t *testing.T) {
+	r := baseRepo(t)
+
+	// Create and stage changes
+	r.WriteFile("base.go", "package main\n\n// unstage me\nfunc base() {}\n")
+	r.Add("base.go")
+
+	err := UnstageFile("base.go")
+	if err != nil {
+		t.Fatalf("UnstageFile: %v", err)
+	}
+
+	staged := r.StagedDiffRaw()
+	if strings.Contains(staged, "unstage me") {
+		t.Errorf("expected no staged changes, got:\n%s", staged)
+	}
+	unstaged := r.UnstagedDiffRaw()
+	if !strings.Contains(unstaged, "unstage me") {
+		t.Errorf("expected unstaged diff to contain 'unstage me', got:\n%s", unstaged)
+	}
+}
+
+func TestDiscardFile(t *testing.T) {
+	r := baseRepo(t)
+
+	r.WriteFile("base.go", "package main\n\n// discard me\nfunc base() {}\n")
+
+	err := DiscardFile("base.go", StatusModified, false)
+	if err != nil {
+		t.Fatalf("DiscardFile: %v", err)
+	}
+
+	status := r.StatusPorcelain()
+	if status != "" {
+		t.Errorf("expected clean working tree, got:\n%s", status)
+	}
+}
+
+func TestDiscardFile_untracked(t *testing.T) {
+	r := baseRepo(t)
+
+	r.WriteFile("newfile.go", "package main\n")
+
+	err := DiscardFile("newfile.go", StatusUntracked, false)
+	if err != nil {
+		t.Fatalf("DiscardFile: %v", err)
+	}
+
+	status := r.StatusPorcelain()
+	if strings.Contains(status, "newfile.go") {
+		t.Errorf("expected newfile.go to be gone, got:\n%s", status)
+	}
+}
+
+func TestDiscardFile_staged(t *testing.T) {
+	r := baseRepo(t)
+
+	r.WriteFile("base.go", "package main\n\n// staged discard\nfunc base() {}\n")
+	r.Add("base.go")
+
+	err := DiscardFile("base.go", StatusModified, true)
+	if err != nil {
+		t.Fatalf("DiscardFile staged: %v", err)
+	}
+
+	status := r.StatusPorcelain()
+	if status != "" {
+		t.Errorf("expected clean working tree, got:\n%s", status)
+	}
+}
+
+func TestDiscardHunk(t *testing.T) {
+	r := baseRepo(t)
+
+	// Create unstaged changes
+	r.WriteFile("base.go", "package main\n\n// discard me\nfunc base() {}\n")
+
+	// Get the unstaged diff to find the hunk
+	raw, err := UnstagedDiff(DefaultContextLines)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := Parse(raw)
+	if len(diff.Files) == 0 {
+		t.Fatal("expected unstaged changes")
+	}
+	file := diff.Files[0]
+	if len(file.Hunks) == 0 {
+		t.Fatal("expected at least one hunk")
+	}
+
+	// Discard the hunk
+	err = DiscardHunk(file.Path, file.Status, file.Hunks[0])
+	if err != nil {
+		t.Fatalf("DiscardHunk: %v", err)
+	}
+
+	// Verify: should have no unstaged changes
+	unstaged := r.UnstagedDiffRaw()
+	if strings.Contains(unstaged, "discard me") {
+		t.Errorf("expected no unstaged changes after discard, got:\n%s", unstaged)
+	}
+
+	// Verify: working tree file should be back to original
+	status := r.StatusPorcelain()
+	if status != "" {
+		t.Errorf("expected clean working tree, got:\n%s", status)
+	}
+}
+
+func TestDiscardHunk_staged(t *testing.T) {
+	r := baseRepo(t)
+
+	// Create and stage changes
+	r.WriteFile("base.go", "package main\n\n// staged discard\nfunc base() {}\n")
+	r.Add("base.go")
+
+	// Get the staged diff to find the hunk
+	raw, err := StagedDiff(DefaultContextLines)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := Parse(raw)
+	if len(diff.Files) == 0 {
+		t.Fatal("expected staged changes")
+	}
+	file := diff.Files[0]
+	if len(file.Hunks) == 0 {
+		t.Fatal("expected at least one hunk")
+	}
+
+	// Discard the staged hunk — should unstage AND revert working tree
+	hunk := file.Hunks[0]
+	hunk.Source = SourceStaged
+	err = DiscardHunk(file.Path, file.Status, hunk)
+	if err != nil {
+		t.Fatalf("DiscardHunk staged: %v", err)
+	}
+
+	// Verify: no staged changes
+	staged := r.StagedDiffRaw()
+	if strings.Contains(staged, "staged discard") {
+		t.Errorf("expected no staged changes, got:\n%s", staged)
+	}
+
+	// Verify: no unstaged changes either (fully discarded)
+	unstaged := r.UnstagedDiffRaw()
+	if strings.Contains(unstaged, "staged discard") {
+		t.Errorf("expected no unstaged changes, got:\n%s", unstaged)
+	}
+
+	// Verify: clean working tree
+	status := r.StatusPorcelain()
+	if status != "" {
+		t.Errorf("expected clean working tree, got:\n%s", status)
+	}
+}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -373,21 +373,26 @@ func formatGutter(l git.Line) string {
 
 func renderHunkHeader(h git.Hunk) string {
 	header := hunkContext(h.Header)
-	if header == "" {
-		return ""
-	}
 
 	style := hunkStyle
+	var label string
 	switch h.Source {
 	case git.SourceBranch:
 		style = hunkBranchStyle
+		label = "branch"
 	case git.SourceStaged:
 		style = hunkStagedStyle
+		label = "staged"
 	case git.SourceUnstaged:
 		style = hunkUnstagedStyle
+		label = "unstaged"
 	}
 
-	return style.Render(header)
+	tag := hunkSourceTagStyle.Render("[" + label + "]")
+	if header == "" {
+		return tag
+	}
+	return tag + " " + style.Render(header)
 }
 
 func hunkContext(header string) string {
@@ -405,6 +410,35 @@ func (m diffViewModel) linePrefix(absIdx int, focused bool) string {
 		return cursorStyle.Render("▶")
 	}
 	return " "
+}
+
+// currentHunkIndex returns the index of the hunk containing the cursor line,
+// or -1 if the cursor is not on a navigable line.
+func (m *diffViewModel) currentHunkIndex() int {
+	if m.file == nil || !m.isNavigable(m.cursor) {
+		return -1
+	}
+
+	// Walk backwards from cursor to find which hunk contains this line.
+	// Hunk boundaries are marked by nil lineRefs (hunk headers / blank separators).
+	hunkIdx := -1
+	for i := m.cursor; i >= 0; i-- {
+		if m.lineRefs[i] == nil {
+			// Count nil→navigable transitions to determine hunk index.
+			break
+		}
+	}
+
+	// Count hunk starts up to and including cursor position.
+	starts := m.hunkStarts()
+	for i, start := range starts {
+		if start <= m.cursor {
+			hunkIdx = i
+		} else {
+			break
+		}
+	}
+	return hunkIdx
 }
 
 // inputBoxHeight is the number of rows the inline comment input box occupies.

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -184,8 +184,8 @@ func TestCursorRef_OnCodeLine(t *testing.T) {
 		}},
 	}
 	m.buildLines()
-	// lines: [0: code, 1: blank] (no hunk context header)
-	m.cursor = 0
+	// lines: [0: source tag, 1: code, 2: blank]
+	m.goToFirstNavigable()
 	ref := m.cursorRef()
 	assert.NotNil(t, ref)
 	key := ref.commentKey("foo.go")
@@ -253,8 +253,41 @@ func TestBuildLines_NoFileHeader(t *testing.T) {
 		}},
 	}
 	m.buildLines()
-	assert.Contains(t, m.lines[0], "hello")
-	assert.NotContains(t, m.lines[0], "foo.go")
+	// No line should contain the file path (title is in the border, not inline)
+	for _, line := range m.lines {
+		assert.NotContains(t, line, "foo.go")
+	}
+}
+
+func TestRenderHunkHeader_ShowsSourceTag(t *testing.T) {
+	tests := []struct {
+		source git.HunkSource
+		tag    string
+	}{
+		{git.SourceBranch, "[branch]"},
+		{git.SourceStaged, "[staged]"},
+		{git.SourceUnstaged, "[unstaged]"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.source), func(t *testing.T) {
+			h := git.Hunk{
+				Header: "@@ -1,3 +1,4 @@ func foo()",
+				Source: tt.source,
+			}
+			got := renderHunkHeader(h)
+			assert.Contains(t, got, tt.tag)
+			assert.Contains(t, got, "func foo()")
+		})
+	}
+}
+
+func TestRenderHunkHeader_EmptyContext_StillShowsTag(t *testing.T) {
+	h := git.Hunk{
+		Header: "@@ -1,1 +1,1 @@",
+		Source: git.SourceStaged,
+	}
+	got := renderHunkHeader(h)
+	assert.Contains(t, got, "[staged]")
 }
 
 func TestHunkContext_ExtractsTrailingContext(t *testing.T) {
@@ -437,6 +470,38 @@ func TestPrevHunk_FromFirstHunk_StaysAtTop(t *testing.T) {
 	m := makeDiffViewModelWithHunks()
 	m.prevHunk()
 	assert.Equal(t, 1, m.lineRefs[m.cursor].newNum) // still on first line
+}
+
+func TestCurrentHunkIndex_FirstHunk(t *testing.T) {
+	m := makeDiffViewModelWithHunks()
+	// Cursor starts on first navigable line of hunk 0
+	assert.Equal(t, 0, m.currentHunkIndex())
+}
+
+func TestCurrentHunkIndex_SecondHunk(t *testing.T) {
+	m := makeDiffViewModelWithHunks()
+	m.nextHunk()
+	assert.Equal(t, 1, m.currentHunkIndex())
+}
+
+func TestCurrentHunkIndex_ThirdHunk(t *testing.T) {
+	m := makeDiffViewModelWithHunks()
+	m.nextHunk()
+	m.nextHunk()
+	assert.Equal(t, 2, m.currentHunkIndex())
+}
+
+func TestCurrentHunkIndex_MiddleOfHunk(t *testing.T) {
+	m := makeDiffViewModelWithHunks()
+	m.nextHunk()
+	m.moveCursorDown(2) // middle of hunk 1
+	assert.Equal(t, 1, m.currentHunkIndex())
+}
+
+func TestCurrentHunkIndex_NoFile(t *testing.T) {
+	m := newDiffViewModel()
+	m.height = 10
+	assert.Equal(t, -1, m.currentHunkIndex())
 }
 
 func TestPrevHunk_FromMiddleOfHunk_GoesToStartOfCurrentHunk(t *testing.T) {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -28,6 +28,9 @@ var allBindings = []BindingGroup{
 	{"File List", []Binding{
 		{"j/k, ↑/↓", "Navigate files"},
 		{"Enter", "Select file and focus diff"},
+		{"s", "Stage file"},
+		{"u", "Unstage file"},
+		{"D", "Discard file"},
 	}},
 	{"Diff View", []Binding{
 		{"j/k, ↑/↓", "Move cursor"},
@@ -37,6 +40,9 @@ var allBindings = []BindingGroup{
 		{"Fn+↓/↑", "Page down/up"},
 		{"Enter/c", "Add/edit comment on line"},
 		{"d", "Delete comment on line"},
+		{"s/S", "Stage hunk/file"},
+		{"u/U", "Unstage hunk/file"},
+		{"D", "Discard hunk"},
 	}},
 	{"Global", []Binding{
 		{"e", "Export comments to clipboard"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -9,10 +9,16 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/justincampbell/revise/internal/git"
 )
 
 type clearStatusMsg struct{}
+
+// hunkApplyMsg is sent when an async hunk stage/unstage/discard completes.
+type hunkApplyMsg struct {
+	err error
+}
 
 // diffLoadedMsg is sent when an async diff load completes.
 type diffLoadedMsg struct {
@@ -59,6 +65,10 @@ type Model struct {
 	commentInputActive bool
 	commentTarget      commentKey
 	statusMsg          string
+
+	confirmDiscard    bool    // waiting for confirmation to discard
+	confirmMsg        string  // message shown in the discard confirmation modal
+	pendingDiscardCmd tea.Cmd // the discard command to run on confirmation
 }
 
 func New(diff *git.Diff, onDefaultBranch bool) Model {
@@ -99,6 +109,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		if m.commentInputActive {
 			return m.updateCommentInput(msg)
+		}
+
+		if m.confirmDiscard {
+			return m.updateConfirmDiscard(msg)
 		}
 
 		if m.showHelp {
@@ -283,6 +297,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.diffView.goToTop()
 		return m, nil
 
+	case hunkApplyMsg:
+		if msg.err != nil {
+			m.statusMsg = "Error: " + msg.err.Error()
+			return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+		}
+		return m, m.loadDiff()
+
 	case clearStatusMsg:
 		m.statusMsg = ""
 		return m, nil
@@ -322,6 +343,18 @@ func (m Model) updateFileList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		m.syncSelectedFile()
 		m.focus = focusDiffView
+	case "s":
+		if cmd := m.stageCurrentFile(); cmd != nil {
+			return m, cmd
+		}
+	case "u":
+		if cmd := m.unstageCurrentFile(); cmd != nil {
+			return m, cmd
+		}
+	case "D":
+		if cmd := m.discardCurrentFile(); cmd != nil {
+			return m, cmd
+		}
 	}
 	return m, nil
 }
@@ -350,6 +383,26 @@ func (m Model) updateDiffView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "d":
 		m.deleteCommentAtCursor()
+	case "s":
+		if cmd := m.stageCurrentHunk(); cmd != nil {
+			return m, cmd
+		}
+	case "u":
+		if cmd := m.unstageCurrentHunk(); cmd != nil {
+			return m, cmd
+		}
+	case "D":
+		if cmd := m.discardCurrentHunk(); cmd != nil {
+			return m, cmd
+		}
+	case "S":
+		if cmd := m.stageCurrentFile(); cmd != nil {
+			return m, cmd
+		}
+	case "U":
+		if cmd := m.unstageCurrentFile(); cmd != nil {
+			return m, cmd
+		}
 	}
 	return m, nil
 }
@@ -377,6 +430,18 @@ func (m Model) updateCommentInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 	return m, nil
+}
+
+func (m Model) updateConfirmDiscard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.confirmDiscard = false
+	m.confirmMsg = ""
+	switch msg.String() {
+	case "y", "Y":
+		return m, m.pendingDiscardCmd
+	default:
+		m.pendingDiscardCmd = nil
+		return m, nil
+	}
 }
 
 func (m *Model) startCommentInput() {
@@ -415,6 +480,133 @@ func (m *Model) deleteCommentAtCursor() {
 	m.diffView.rebuildLinesPreservingCursor()
 }
 
+// stageCurrentHunk stages the hunk at the cursor. Only works on unstaged hunks.
+func (m *Model) stageCurrentHunk() tea.Cmd {
+	idx := m.diffView.currentHunkIndex()
+	if idx < 0 || m.diffView.file == nil {
+		return nil
+	}
+	hunk := m.diffView.file.Hunks[idx]
+	if hunk.Source != git.SourceUnstaged {
+		m.statusMsg = "Can only stage unstaged hunks"
+		return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+	}
+	path := m.diffView.file.Path
+	status := m.diffView.file.Status
+	return func() tea.Msg {
+		err := git.StageHunk(path, status, hunk)
+		return hunkApplyMsg{err: err}
+	}
+}
+
+// unstageCurrentHunk unstages the hunk at the cursor. Only works on staged hunks.
+func (m *Model) unstageCurrentHunk() tea.Cmd {
+	idx := m.diffView.currentHunkIndex()
+	if idx < 0 || m.diffView.file == nil {
+		return nil
+	}
+	hunk := m.diffView.file.Hunks[idx]
+	if hunk.Source != git.SourceStaged {
+		m.statusMsg = "Can only unstage staged hunks"
+		return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+	}
+	path := m.diffView.file.Path
+	status := m.diffView.file.Status
+	return func() tea.Msg {
+		err := git.UnstageHunk(path, status, hunk)
+		return hunkApplyMsg{err: err}
+	}
+}
+
+// discardCurrentHunk prompts for confirmation, then discards the hunk at the cursor.
+func (m *Model) discardCurrentHunk() tea.Cmd {
+	idx := m.diffView.currentHunkIndex()
+	if idx < 0 || m.diffView.file == nil {
+		return nil
+	}
+	hunk := m.diffView.file.Hunks[idx]
+	if hunk.Source == git.SourceBranch {
+		m.statusMsg = "Cannot discard committed changes"
+		return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+	}
+	path := m.diffView.file.Path
+	status := m.diffView.file.Status
+	m.confirmDiscard = true
+	m.confirmMsg = "Discard hunk? This cannot be undone."
+	m.pendingDiscardCmd = func() tea.Msg {
+		err := git.DiscardHunk(path, status, hunk)
+		return hunkApplyMsg{err: err}
+	}
+	return nil
+}
+
+// stageCurrentFile stages all unstaged changes in the current file.
+func (m *Model) stageCurrentFile() tea.Cmd {
+	file := m.diffView.file
+	if file == nil {
+		return nil
+	}
+	if !fileHasSource(file, git.SourceUnstaged) {
+		m.statusMsg = "No unstaged changes to stage"
+		return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+	}
+	path := file.Path
+	return func() tea.Msg {
+		err := git.StageFile(path)
+		return hunkApplyMsg{err: err}
+	}
+}
+
+// unstageCurrentFile unstages all staged changes in the current file.
+func (m *Model) unstageCurrentFile() tea.Cmd {
+	file := m.diffView.file
+	if file == nil {
+		return nil
+	}
+	if !fileHasSource(file, git.SourceStaged) {
+		m.statusMsg = "No staged changes to unstage"
+		return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+	}
+	path := file.Path
+	return func() tea.Msg {
+		err := git.UnstageFile(path)
+		return hunkApplyMsg{err: err}
+	}
+}
+
+// discardCurrentFile prompts for confirmation, then discards all changes in the current file.
+func (m *Model) discardCurrentFile() tea.Cmd {
+	file := m.diffView.file
+	if file == nil {
+		return nil
+	}
+	hasUnstaged := fileHasSource(file, git.SourceUnstaged)
+	hasStaged := fileHasSource(file, git.SourceStaged)
+	if !hasUnstaged && !hasStaged {
+		m.statusMsg = "No changes to discard"
+		return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+	}
+	path := file.Path
+	status := file.Status
+	m.confirmDiscard = true
+	m.confirmMsg = "Discard all changes to " + path + "?\nThis cannot be undone."
+	m.pendingDiscardCmd = func() tea.Msg {
+		err := git.DiscardFile(path, status, hasStaged)
+		return hunkApplyMsg{err: err}
+	}
+	return nil
+}
+
+// fileHasSource returns true if any hunk in the file has the given source.
+func fileHasSource(f *git.FileDiff, source git.HunkSource) bool {
+	for _, h := range f.Hunks {
+		if h.Source == source {
+			return true
+		}
+	}
+	return false
+}
+
 // exportComments copies comments to the clipboard or writes to a file.
 // Returns a status string describing what happened, or "" if there's nothing to export.
 func (m *Model) exportComments() string {
@@ -435,6 +627,67 @@ func (m *Model) exportComments() string {
 	}
 	_ = os.WriteFile(".revise-comments.md", []byte(text), 0644)
 	return "Saved to .revise-comments.md"
+}
+
+func (m Model) renderConfirmDialog() string {
+	content := m.confirmMsg + "\n\n" +
+		confirmKeyStyle.Render("y") + " confirm    " +
+		"any key to cancel"
+
+	return confirmStyle.Render(content)
+}
+
+// overlayCenter draws fg centered on top of bg, replacing the background characters.
+func overlayCenter(bg, fg string, width, height int) string {
+	bgLines := strings.Split(bg, "\n")
+	fgLines := strings.Split(fg, "\n")
+
+	fgH := len(fgLines)
+	fgW := 0
+	for _, l := range fgLines {
+		if w := ansi.StringWidth(l); w > fgW {
+			fgW = w
+		}
+	}
+
+	startY := (height - fgH) / 2
+	startX := (width - fgW) / 2
+	if startY < 0 {
+		startY = 0
+	}
+	if startX < 0 {
+		startX = 0
+	}
+
+	for i, fgLine := range fgLines {
+		row := startY + i
+		if row >= len(bgLines) {
+			break
+		}
+		bgLine := bgLines[row]
+		bgW := ansi.StringWidth(bgLine)
+
+		var left string
+		if startX > 0 && bgW > 0 {
+			left = ansi.Truncate(bgLine, startX, "")
+		}
+		// Pad left to startX if background is shorter
+		for ansi.StringWidth(left) < startX {
+			left += " "
+		}
+
+		fgLineW := ansi.StringWidth(fgLine)
+		rightStart := startX + fgLineW
+		var right string
+		if rightStart < bgW {
+			// Cut the right portion from the background
+			right = ansi.TruncateLeft(bgLine, rightStart, "")
+		}
+
+		bgLines[row] = left + fgLine + right
+	}
+
+	return strings.Join(bgLines, "\n")
 }
 
 func (m Model) mouseFocusDiff(msg tea.MouseMsg) bool {
@@ -598,13 +851,20 @@ func (m Model) View() string {
 
 	statusBar := m.renderStatusBar()
 
+	var screen string
 	if m.fullscreen {
 		panels := m.diffView.render(true)
-		return lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
+		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
+	} else {
+		left := m.fileList.render(m.focus == focusFileList)
+		right := m.diffView.render(m.focus == focusDiffView)
+		panels := lipgloss.JoinHorizontal(lipgloss.Top, left, " ", right)
+		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
 	}
 
-	left := m.fileList.render(m.focus == focusFileList)
-	right := m.diffView.render(m.focus == focusDiffView)
-	panels := lipgloss.JoinHorizontal(lipgloss.Top, left, " ", right)
-	return lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
+	if m.confirmDiscard {
+		screen = overlayCenter(screen, m.renderConfirmDialog(), m.width, m.height)
+	}
+
+	return screen
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -558,6 +558,235 @@ func TestModelUnderscore_DecreasesContextLines(t *testing.T) {
 	assert.Equal(t, 4, m.contextLines)
 }
 
+// --- Stage/Unstage/Discard tests ---
+
+// makeModelWithSourcedHunk creates a model with a single hunk from the given source.
+func makeModelWithSourcedHunk(source git.HunkSource) Model {
+	hunk := git.Hunk{
+		Header:   "@@ -1,3 +1,4 @@",
+		Source:   source,
+		OldStart: 1, OldCount: 3, NewStart: 1, NewCount: 4,
+		Lines: []git.Line{
+			{Type: git.LineContext, Content: "a", OldNum: 1, NewNum: 1},
+			{Type: git.LineAdded, Content: "b", NewNum: 2},
+			{Type: git.LineContext, Content: "c", OldNum: 2, NewNum: 3},
+			{Type: git.LineContext, Content: "d", OldNum: 3, NewNum: 4},
+		},
+	}
+	files := []git.FileDiff{{
+		Path:   "test.go",
+		Status: git.StatusModified,
+		Hunks:  []git.Hunk{hunk},
+	}}
+	m := New(&git.Diff{Files: files}, false)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	return updated.(Model)
+}
+
+func TestModelStageKey_OnUnstagedHunk_ReturnsCmd(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	m = sendKey(m, "l") // focus diff
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	m = updated.(Model)
+	assert.NotNil(t, cmd, "should return a command for staging")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelStageKey_OnStagedHunk_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceStaged)
+	m = sendKey(m, "l") // focus diff
+	m = sendKey(m, "s")
+	assert.Contains(t, m.statusMsg, "unstaged")
+}
+
+func TestModelStageKey_OnBranchHunk_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceBranch)
+	m = sendKey(m, "l") // focus diff
+	m = sendKey(m, "s")
+	assert.Contains(t, m.statusMsg, "unstaged")
+}
+
+func TestModelUnstageKey_OnStagedHunk_ReturnsCmd(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceStaged)
+	m = sendKey(m, "l") // focus diff
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	m = updated.(Model)
+	assert.NotNil(t, cmd, "should return a command for unstaging")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelUnstageKey_OnUnstagedHunk_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	m = sendKey(m, "l") // focus diff
+	m = sendKey(m, "u")
+	assert.Contains(t, m.statusMsg, "staged")
+}
+
+func TestModelDiscardKey_OnUnstagedHunk_PromptsConfirmation(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	assert.True(t, m.confirmDiscard)
+	assert.Contains(t, m.confirmMsg, "cannot be undone")
+}
+
+func TestModelDiscardKey_ConfirmWithY_ReturnsCmd(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	require.True(t, m.confirmDiscard)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m = updated.(Model)
+	assert.False(t, m.confirmDiscard)
+	assert.NotNil(t, cmd, "should return a command after confirmation")
+}
+
+func TestModelDiscardKey_CancelWithOtherKey(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	require.True(t, m.confirmDiscard)
+	m = sendKey(m, "n")
+	assert.False(t, m.confirmDiscard)
+	assert.Empty(t, m.confirmMsg)
+}
+
+func TestModelDiscardKey_OnStagedHunk_PromptsConfirmation(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceStaged)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	assert.True(t, m.confirmDiscard)
+	assert.Contains(t, m.confirmMsg, "cannot be undone")
+}
+
+func TestModelDiscardKey_OnBranchHunk_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceBranch)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "committed")
+	assert.False(t, m.confirmDiscard)
+}
+
+func TestModelStageFileKey_WithUnstagedHunks_ReturnsCmd(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	m = sendKey(m, "l") // focus diff
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")})
+	m = updated.(Model)
+	assert.NotNil(t, cmd, "should return a command for staging file")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelStageFileKey_NoUnstagedHunks_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceStaged)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "No unstaged")
+}
+
+func TestModelStageFileKey_BranchHunksOnly_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceBranch)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "No unstaged")
+}
+
+func TestModelUnstageFileKey_WithStagedHunks_ReturnsCmd(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceStaged)
+	m = sendKey(m, "l") // focus diff
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("U")})
+	m = updated.(Model)
+	assert.NotNil(t, cmd, "should return a command for unstaging file")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelUnstageFileKey_NoStagedHunks_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("U")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "No staged")
+}
+
+// --- File list stage/unstage tests ---
+
+func TestModelFileList_S_StagesFile(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	require.Equal(t, focusFileList, m.focus)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	m = updated.(Model)
+	assert.NotNil(t, cmd, "should return a command for staging file")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelFileList_S_NoUnstaged_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceStaged)
+	require.Equal(t, focusFileList, m.focus)
+	m = sendKey(m, "s")
+	assert.Contains(t, m.statusMsg, "No unstaged")
+}
+
+func TestModelFileList_U_UnstagesFile(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceStaged)
+	require.Equal(t, focusFileList, m.focus)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	m = updated.(Model)
+	assert.NotNil(t, cmd, "should return a command for unstaging file")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelFileList_U_NoStaged_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	require.Equal(t, focusFileList, m.focus)
+	m = sendKey(m, "u")
+	assert.Contains(t, m.statusMsg, "No staged")
+}
+
+func TestModelFileList_D_PromptsConfirmation(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	require.Equal(t, focusFileList, m.focus)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	assert.True(t, m.confirmDiscard)
+	assert.Contains(t, m.confirmMsg, "cannot be undone")
+}
+
+func TestModelFileList_D_ConfirmWithY_ReturnsCmd(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	require.Equal(t, focusFileList, m.focus)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	require.True(t, m.confirmDiscard)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m = updated.(Model)
+	assert.False(t, m.confirmDiscard)
+	assert.NotNil(t, cmd, "should return a command after confirmation")
+}
+
+func TestModelFileList_D_StagedFile_PromptsConfirmation(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceStaged)
+	require.Equal(t, focusFileList, m.focus)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	assert.True(t, m.confirmDiscard)
+	assert.Contains(t, m.confirmMsg, "cannot be undone")
+}
+
+func TestModelFileList_D_BranchOnlyFile_ShowsError(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceBranch)
+	require.Equal(t, focusFileList, m.focus)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "No changes")
+	assert.False(t, m.confirmDiscard)
+}
+
 func TestRenderStatusBar_FileListNoPaneTotals(t *testing.T) {
 	m := makeModelWithDiff("foo.go", []git.Line{
 		{Type: git.LineAdded, Content: "a", NewNum: 1},

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -27,9 +27,10 @@ var (
 	removedStyle      = lipgloss.NewStyle().Foreground(colorRed).Background(colorRemovedBg)
 	contextStyle      = lipgloss.NewStyle().Foreground(colorDim)
 	hunkStyle         = lipgloss.NewStyle().Foreground(colorCyan)
-	hunkBranchStyle   = lipgloss.NewStyle().Foreground(colorDim)
-	hunkStagedStyle   = lipgloss.NewStyle().Foreground(colorCyan)
-	hunkUnstagedStyle = lipgloss.NewStyle().Foreground(colorYellow)
+	hunkBranchStyle      = lipgloss.NewStyle().Foreground(colorDim)
+	hunkStagedStyle      = lipgloss.NewStyle().Foreground(colorCyan)
+	hunkUnstagedStyle    = lipgloss.NewStyle().Foreground(colorYellow)
+	hunkSourceTagStyle   = lipgloss.NewStyle().Foreground(colorDim).Italic(true)
 	fileStyle         = lipgloss.NewStyle().Bold(true).Foreground(colorWhite)
 
 	// Gutter styles
@@ -85,6 +86,13 @@ var (
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(colorCyan).
 			Padding(1, 2)
+
+	// Confirm dialog styles
+	confirmStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorRed).
+			Padding(1, 2)
+	confirmKeyStyle = lipgloss.NewStyle().Bold(true).Foreground(colorRed)
 )
 
 func init() {
@@ -96,6 +104,7 @@ func init() {
 		hunkBranchStyle = lipgloss.NewStyle()
 		hunkStagedStyle = lipgloss.NewStyle()
 		hunkUnstagedStyle = lipgloss.NewStyle()
+		hunkSourceTagStyle = lipgloss.NewStyle()
 		fileStyle = lipgloss.NewStyle().Bold(true)
 		selectedStyle = lipgloss.NewStyle().Bold(true)
 		unselectedStyle = lipgloss.NewStyle()
@@ -118,5 +127,7 @@ func init() {
 		helpKeyStyle = lipgloss.NewStyle().Bold(true)
 		helpDescStyle = lipgloss.NewStyle()
 		helpStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2)
+		confirmStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2)
+		confirmKeyStyle = lipgloss.NewStyle().Bold(true)
 	}
 }


### PR DESCRIPTION
Closes #2

## Summary
- **Hunk-level operations**: `s` to stage, `u` to unstage, `D` to discard individual hunks from the diff view
- **File-level operations**: `S`/`U`/`D` in diff view, or `s`/`u`/`D` from the file list
- **Discard confirmation**: centered modal overlay (draws over existing UI) requiring `y` to confirm
- **Hunk source tags**: each hunk header now shows `[staged]`, `[unstaged]`, or `[branch]` label
- Handles edge cases: untracked files (falls back to `git add`), staged hunk discard (unstages then reverts)

## Test plan
- `go test ./...` passes (new tests for all git operations and UI key routing)
- Manual: stage/unstage/discard hunks and files across staged, unstaged, and untracked changes
- Verify discard modal appears and cancels with any key besides `y`