### PR TITLE
Filter out branch-added files that were later deleted

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -349,26 +349,46 @@ func tagHunks(files []FileDiff, source HunkSource) {
 // mergeFileDiffs combines two sets of file diffs.
 // For the same path, hunks from both are combined (base first, then overlay).
 // New paths are appended. The inputs are not mutated.
+// If a file was added in base and deleted in overlay, it is removed entirely
+// (net zero change — e.g. file added on branch then deleted in working tree).
 func mergeFileDiffs(base, overlay []FileDiff) []FileDiff {
 	result := make([]FileDiff, len(base))
 	copy(result, base)
 
 	seen := make(map[string]int, len(result))
+	baseStatus := make(map[string]FileStatus, len(result))
 	for i, f := range result {
 		seen[f.Path] = i
+		baseStatus[f.Path] = f.Status
 	}
 
+	remove := make(map[int]bool)
 	for _, f := range overlay {
 		if idx, ok := seen[f.Path]; ok {
-			// Same file — combine hunks
-			combined := make([]Hunk, len(result[idx].Hunks), len(result[idx].Hunks)+len(f.Hunks))
-			copy(combined, result[idx].Hunks)
-			combined = append(combined, f.Hunks...)
-			result[idx].Hunks = combined
+			if f.Status == StatusDeleted && baseStatus[f.Path] == StatusAdded {
+				// Added in base, deleted in overlay — net zero
+				remove[idx] = true
+			} else {
+				// Same file — combine hunks
+				combined := make([]Hunk, len(result[idx].Hunks), len(result[idx].Hunks)+len(f.Hunks))
+				copy(combined, result[idx].Hunks)
+				combined = append(combined, f.Hunks...)
+				result[idx].Hunks = combined
+			}
 		} else {
 			result = append(result, f)
 			seen[f.Path] = len(result) - 1
 		}
+	}
+
+	if len(remove) > 0 {
+		filtered := make([]FileDiff, 0, len(result)-len(remove))
+		for i, f := range result {
+			if !remove[i] {
+				filtered = append(filtered, f)
+			}
+		}
+		return filtered
 	}
 
 	return result

--- a/internal/git/diff_integration_test.go
+++ b/internal/git/diff_integration_test.go
@@ -309,6 +309,67 @@ func TestGetDiff_FeatureBranch_UsesOriginMain(t *testing.T) {
 }
 
 // ============================================================================
+// GetDiff — files added on branch then removed (net zero)
+// ============================================================================
+
+func TestGetDiff_FeatureBranch_AddedThenDeletedCommitted(t *testing.T) {
+	r := NewTestRepo(t)
+	r.WriteFile("base.go", "package main\n\nfunc base() {}\n")
+	r.Add("base.go")
+	r.Commit("initial")
+	r.CheckoutNewBranch("feature")
+	r.WriteFile("temp.go", "package main\n\nfunc temp() {}\n")
+	r.Add("temp.go")
+	r.Commit("add temp")
+	r.mustGit("rm", "temp.go")
+	r.Commit("remove temp")
+	r.Chdir()
+
+	diff, err := GetDiff()
+	require.NoError(t, err)
+	assert.Empty(t, diff.Files, "file added then removed in commits should not appear")
+}
+
+func TestGetDiff_FeatureBranch_AddedThenDeletedStaged(t *testing.T) {
+	r := featureBranchRepo(t)
+	r.mustGit("rm", "feature.go")
+
+	diff, err := GetDiff()
+	require.NoError(t, err)
+	assert.Empty(t, diff.Files, "file added on branch then staged for deletion should not appear")
+}
+
+func TestGetDiff_FeatureBranch_AddedThenDeletedUnstaged(t *testing.T) {
+	r := featureBranchRepo(t)
+	r.RemoveFile("feature.go")
+
+	diff, err := GetDiff()
+	require.NoError(t, err)
+	assert.Empty(t, diff.Files, "file added on branch then deleted from working tree should not appear")
+}
+
+func TestGetDiff_FeatureBranch_AddedThenRenamed(t *testing.T) {
+	r := NewTestRepo(t)
+	r.WriteFile("base.go", "package main\n\nfunc base() {}\n")
+	r.Add("base.go")
+	r.Commit("initial")
+	r.CheckoutNewBranch("feature")
+	r.WriteFile("temp.go", "package main\n\nfunc temp() {}\n")
+	r.Add("temp.go")
+	r.Commit("add temp")
+	r.mustGit("mv", "temp.go", "renamed.go")
+	r.Commit("rename temp to renamed")
+	r.Chdir()
+
+	diff, err := GetDiff()
+	require.NoError(t, err)
+	// The net effect is: renamed.go is a new file (temp.go never existed on main)
+	paths := filePaths(diff)
+	assert.NotContains(t, paths, "temp.go", "original name should not appear")
+	assert.Contains(t, paths, "renamed.go", "renamed file should appear")
+}
+
+// ============================================================================
 // GetDiff — deleted and renamed files
 // ============================================================================
 

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -40,6 +40,35 @@ func TestMergeFileDiffs_AppendsNewPath(t *testing.T) {
 	assert.Equal(t, "new.go", result[1].Path)
 }
 
+func TestMergeFileDiffs_AddedThenDeleted(t *testing.T) {
+	branch := []FileDiff{
+		{Path: "temp.go", Status: StatusAdded},
+		{Path: "keep.go", Status: StatusModified},
+	}
+	wt := []FileDiff{
+		{Path: "temp.go", Status: StatusDeleted},
+	}
+
+	result := mergeFileDiffs(branch, wt)
+
+	require.Len(t, result, 1, "temp.go should be removed (added then deleted = net zero)")
+	assert.Equal(t, "keep.go", result[0].Path)
+}
+
+func TestMergeFileDiffs_ModifiedThenDeleted(t *testing.T) {
+	branch := []FileDiff{
+		{Path: "existing.go", Status: StatusModified, Hunks: []Hunk{{Header: "@@ branch @@", Source: SourceBranch}}},
+	}
+	wt := []FileDiff{
+		{Path: "existing.go", Status: StatusDeleted, Hunks: []Hunk{{Header: "@@ delete @@", Source: SourceStaged}}},
+	}
+
+	result := mergeFileDiffs(branch, wt)
+
+	require.Len(t, result, 1, "modified then deleted should still appear (file existed before branch)")
+	require.Len(t, result[0].Hunks, 2, "should combine hunks from both")
+}
+
 func TestMergeFileDiffs_EmptyInputs(t *testing.T) {
 	result := mergeFileDiffs(nil, nil)
 	assert.Empty(t, result)


### PR DESCRIPTION
## Summary
When a file is added on a feature branch and then deleted (staged, unstaged, or committed), mergeFileDiffs now removes it entirely instead of showing it as Deleted. The net change from the default branch perspective is zero, so the file should not appear.

Fixes #47

## Test plan
- [x] Unit tests for mergeFileDiffs added-then-deleted and modified-then-deleted cases
- [x] Integration tests for committed, staged, and unstaged deletion of branch-added files
- [x] Integration test for rename of branch-added file
- [x] Full test suite passes