### PR TITLE
Fix branch diff showing remote changes for zero-commit feature branches

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -136,6 +136,16 @@ func resolveRef(ref string) string {
 	return strings.TrimSpace(string(out))
 }
 
+// CurrentBranchName returns the name of the currently checked out branch,
+// or "" if in detached HEAD state.
+func CurrentBranchName() string {
+	out, err := exec.Command("git", "symbolic-ref", "--short", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // IsOnDefaultBranch returns true if the current HEAD is at the merge-base
 // with the default branch AND up to date with the remote tracking branch.
 // Returns false when on a feature branch (merge-base != HEAD) or when on
@@ -167,10 +177,18 @@ func IsOnDefaultBranch() (bool, error) {
 	}
 
 	if mergeBase != head {
-		return false, nil // feature branch
+		return false, nil // feature branch with commits
 	}
 
-	// merge-base == HEAD: we're on or at the default branch.
+	// merge-base == HEAD: no commits diverging from the default branch.
+	// If we're on a differently-named branch (feature branch with zero
+	// commits), treat as default branch — show working tree only.
+	currentBranch := CurrentBranchName()
+	if currentBranch != "" && currentBranch != branch {
+		return true, nil // feature branch with no commits — show working tree
+	}
+
+	// Actually on the default branch.
 	// Check if the remote tracking branch has different commits.
 	if remote != "" {
 		remoteRef := resolveRef(remote + "/" + branch)

--- a/internal/git/diff_integration_test.go
+++ b/internal/git/diff_integration_test.go
@@ -456,6 +456,14 @@ func TestIsOnDefaultBranch_OnFeatureBranch(t *testing.T) {
 	assert.False(t, onDefault)
 }
 
+func TestIsOnDefaultBranch_FeatureBranchNoCommitsBehindRemote(t *testing.T) {
+	r := behindRemoteRepo(t)
+	r.CheckoutNewBranch("feature-no-commits")
+	onDefault, err := IsOnDefaultBranch()
+	require.NoError(t, err)
+	assert.True(t, onDefault, "feature branch with no commits should be treated as default branch")
+}
+
 func TestIsOnDefaultBranch_BehindRemote(t *testing.T) {
 	r := behindRemoteRepo(t)
 	_ = r


### PR DESCRIPTION
## Summary
When on a feature branch with no commits of its own and origin/main has moved ahead, branch mode was incorrectly showing the remote's incoming changes as the diff. Now checks the actual branch name — if it differs from the default branch, treats it as working-tree-only mode regardless of merge-base position.

## Test plan
- [x] New test: feature branch with no commits behind remote returns true from IsOnDefaultBranch
- [x] Existing behind-remote and ahead-of-remote tests still pass
- [x] Full test suite passes
- [ ] Manual: run revise in a repo with a zero-commit feature branch behind origin/main