### PR TITLE
Allow Enter to confirm discard

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -436,7 +436,7 @@ func (m Model) updateConfirmDiscard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.confirmDiscard = false
 	m.confirmMsg = ""
 	switch msg.String() {
-	case "y", "Y":
+	case "y", "Y", "enter":
 		return m, m.pendingDiscardCmd
 	default:
 		m.pendingDiscardCmd = nil
@@ -631,7 +631,7 @@ func (m *Model) exportComments() string {
 
 func (m Model) renderConfirmDialog() string {
 	content := m.confirmMsg + "\n\n" +
-		confirmKeyStyle.Render("y") + " confirm    " +
+		confirmKeyStyle.Render("y") + "/" + confirmKeyStyle.Render("Enter") + " confirm    " +
 		"any key to cancel"
 
 	return confirmStyle.Render(content)

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -643,6 +643,18 @@ func TestModelDiscardKey_ConfirmWithY_ReturnsCmd(t *testing.T) {
 	assert.NotNil(t, cmd, "should return a command after confirmation")
 }
 
+func TestModelDiscardKey_ConfirmWithEnter(t *testing.T) {
+	m := makeModelWithSourcedHunk(git.SourceUnstaged)
+	m = sendKey(m, "l") // focus diff
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	require.True(t, m.confirmDiscard)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	assert.False(t, m.confirmDiscard)
+	assert.NotNil(t, cmd, "Enter should confirm discard")
+}
+
 func TestModelDiscardKey_CancelWithOtherKey(t *testing.T) {
 	m := makeModelWithSourcedHunk(git.SourceUnstaged)
 	m = sendKey(m, "l") // focus diff


### PR DESCRIPTION
## Summary
- Accept Enter key in addition to `y`/`Y` to confirm discard operations
- Updated confirm dialog to show `y/Enter confirm` hint
- Added test for Enter confirmation

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)