### PR TITLE
Update mode display to use + delimiter between active modes

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -791,22 +791,38 @@ func (m Model) renderModeSlider() string {
 		}
 		return modeInactiveStyle.Render(name)
 	}
-	sep := modeInactiveStyle.Render("·")
 
-	var parts []string
+	type label struct {
+		name   string
+		active bool
+	}
+	var labels []label
 
 	// Cumulative: broadest mode (ModeBranch) lights all,
 	// narrower modes drop components from the left.
 	if !m.onDefaultBranch {
-		parts = append(parts, render("Branch", m.mode == ModeBranch))
+		labels = append(labels, label{"Branch", m.mode == ModeBranch})
 	}
-	parts = append(parts,
-		render("Staged", m.mode == ModeBranch || m.mode == ModeStaged),
-		render("Unstaged", true),
+	labels = append(labels,
+		label{"Staged", m.mode == ModeBranch || m.mode == ModeStaged},
+		label{"Unstaged", true},
 	)
 
+	var result string
+	for i, l := range labels {
+		if i > 0 {
+			// Use + between two active labels, space otherwise
+			if labels[i-1].active && l.active {
+				result += modeActiveStyle.Render("+")
+			} else {
+				result += modeInactiveStyle.Render(" ")
+			}
+		}
+		result += render(l.name, l.active)
+	}
+
 	ctx := fmt.Sprintf("  +/-: context (%d)", m.contextLines)
-	return strings.Join(parts, sep) + modeInactiveStyle.Render("  Tab: switch") + modeInactiveStyle.Render(ctx)
+	return result + modeInactiveStyle.Render("  Tab: switch") + modeInactiveStyle.Render(ctx)
 }
 
 func (m Model) renderStatusBar() string {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -388,6 +388,30 @@ func TestModeSlider_DefaultBranch_OmitsBranch(t *testing.T) {
 	assert.Contains(t, slider, "Unstaged")
 }
 
+func TestModeSlider_BranchMode_PlusDelimiters(t *testing.T) {
+	m := makeModel("a.go") // feature branch, ModeBranch
+	slider := m.renderModeSlider()
+	// All active — should use + between all labels
+	assert.Contains(t, slider, "+")
+	assert.NotContains(t, slider, "·")
+}
+
+func TestModeSlider_StagedMode_MixedDelimiters(t *testing.T) {
+	m := makeModel("a.go")
+	m.mode = ModeStaged
+	slider := m.renderModeSlider()
+	// Branch inactive, Staged+Unstaged active — + between Staged and Unstaged, space before Staged
+	assert.Contains(t, slider, "+")
+}
+
+func TestModeSlider_UnstagedMode_SpaceDelimiters(t *testing.T) {
+	m := makeModel("a.go")
+	m.mode = ModeUnstaged
+	slider := m.renderModeSlider()
+	// Only Unstaged active — space delimiters between labels, no +
+	assert.Contains(t, slider, "Branch Staged Unstaged")
+}
+
 // --- Slider click tests ---
 
 func TestSliderModeAt_FeatureBranch_ClickBranch(t *testing.T) {


### PR DESCRIPTION
## Summary
- Active modes joined with `+` (e.g. `Branch+Staged+Unstaged`)
- Inactive modes separated by spaces (e.g. `Branch Staged+Unstaged`)
- Slider click positions unchanged (all separators remain 1 cell wide)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)