### PR TITLE
Handle/retry lock contention for git index operations

### DIFF
--- a/internal/git/apply.go
+++ b/internal/git/apply.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // HunkPatch reconstructs a unified diff patch for a single hunk,
@@ -73,20 +74,24 @@ func DiscardHunk(path string, status FileStatus, h Hunk) error {
 
 // StageFile stages an entire file.
 func StageFile(path string) error {
-	out, err := exec.Command("git", "add", "--", path).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git add: %s\n%s", err, string(out))
-	}
-	return nil
+	return withRetry(func() error {
+		out, err := exec.Command("git", "add", "--", path).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git add: %s\n%s", err, string(out))
+		}
+		return nil
+	})
 }
 
 // UnstageFile unstages an entire file (keeps working tree changes).
 func UnstageFile(path string) error {
-	out, err := exec.Command("git", "reset", "HEAD", "--", path).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git reset: %s\n%s", err, string(out))
-	}
-	return nil
+	return withRetry(func() error {
+		out, err := exec.Command("git", "reset", "HEAD", "--", path).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git reset: %s\n%s", err, string(out))
+		}
+		return nil
+	})
 }
 
 // DiscardFile discards all changes to a file.
@@ -104,21 +109,50 @@ func DiscardFile(path string, status FileStatus, staged bool) error {
 			return err
 		}
 	}
-	out, err := exec.Command("git", "checkout", "--", path).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git checkout: %s\n%s", err, string(out))
+	return withRetry(func() error {
+		out, err := exec.Command("git", "checkout", "--", path).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git checkout: %s\n%s", err, string(out))
+		}
+		return nil
+	})
+}
+
+// isLockError returns true if the error is caused by a git index.lock contention.
+func isLockError(err error) bool {
+	if err == nil {
+		return false
 	}
-	return nil
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "index.lock") || strings.Contains(msg, "unable to create") && strings.Contains(msg, "lock")
+}
+
+// withRetry retries fn up to 5 times with backoff when it fails due to lock contention.
+func withRetry(fn func() error) error {
+	const maxRetries = 5
+	delay := 50 * time.Millisecond
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		err = fn()
+		if err == nil || !isLockError(err) {
+			return err
+		}
+		time.Sleep(delay)
+		delay *= 2
+	}
+	return err
 }
 
 // gitApply runs git apply with the given flags, piping patch to stdin.
 func gitApply(patch string, flags ...string) error {
-	args := append([]string{"apply"}, flags...)
-	cmd := exec.Command("git", args...)
-	cmd.Stdin = strings.NewReader(patch)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git apply: %s\n%s", err, string(out))
-	}
-	return nil
+	return withRetry(func() error {
+		args := append([]string{"apply"}, flags...)
+		cmd := exec.Command("git", args...)
+		cmd.Stdin = strings.NewReader(patch)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git apply: %s\n%s", err, string(out))
+		}
+		return nil
+	})
 }

--- a/internal/git/apply_test.go
+++ b/internal/git/apply_test.go
@@ -1,8 +1,12 @@
 package git
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHunkPatch(t *testing.T) {
@@ -199,6 +203,64 @@ func TestStageHunk_untrackedFile(t *testing.T) {
 	if strings.Contains(status, "??") {
 		t.Errorf("expected file to no longer be untracked, got:\n%s", status)
 	}
+}
+
+func TestIsLockError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"normal error", fmt.Errorf("some error"), false},
+		{"lock error", fmt.Errorf("git add: exit status 128\nfatal: Unable to create '/repo/.git/index.lock': File exists."), true},
+		{"lock error lowercase", fmt.Errorf("unable to create 'index.lock': File exists"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLockError(tt.err); got != tt.want {
+				t.Errorf("isLockError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStageFile_RetryOnLock(t *testing.T) {
+	r := baseRepo(t)
+
+	r.WriteFile("base.go", "package main\n\n// retry test\nfunc base() {}\n")
+
+	// Create a lock file to simulate contention
+	gitDir := findGitDir(t)
+	lockPath := gitDir + "/index.lock"
+	if err := os.WriteFile(lockPath, []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove the lock after a short delay to simulate transient contention
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		os.Remove(lockPath)
+	}()
+
+	err := StageFile("base.go")
+	if err != nil {
+		t.Fatalf("StageFile should have retried and succeeded: %v", err)
+	}
+
+	staged := r.StagedDiffRaw()
+	if !strings.Contains(staged, "retry test") {
+		t.Errorf("expected staged diff to contain 'retry test', got:\n%s", staged)
+	}
+}
+
+func findGitDir(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("git", "rev-parse", "--git-dir").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func TestStageFile(t *testing.T) {


### PR DESCRIPTION
## Summary
- Added retry with exponential backoff (50ms-800ms, 5 attempts) for git index lock contention
- Wrapped all index-touching operations: `StageFile`, `UnstageFile`, `DiscardFile`, `gitApply`
- Integration test creates actual lock file and verifies retry succeeds

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)