### PR TITLE
Add ! key to report issues on GitHub

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -46,6 +46,7 @@ var allBindings = []BindingGroup{
 	}},
 	{"Global", []Binding{
 		{"e", "Export comments to clipboard"},
+		{"!", "Report issue on GitHub"},
 	}},
 	{"Comment Input", []Binding{
 		{"Enter", "Save comment"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -187,6 +187,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
+		// Report issue opens GitHub new issue page
+		case "!":
+			const issueURL = "https://github.com/justincampbell/revise/issues/new"
+			m.statusMsg = "Opening " + issueURL
+			return m, tea.Batch(
+				func() tea.Msg {
+					_ = exec.Command("open", issueURL).Start()
+					return nil
+				},
+				tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} }),
+			)
+
 		// Export works from any panel
 		case "e":
 			msg := m.exportComments()

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -505,6 +505,23 @@ func TestModelExport_NoCommentsNoStatus(t *testing.T) {
 	assert.Empty(t, m.statusMsg)
 }
 
+func TestModelReportIssue_SetsStatusAndReturnsCmd(t *testing.T) {
+	m := makeModel("a.go")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "Opening")
+	assert.NotNil(t, cmd, "should return a command to open the URL")
+}
+
+func TestModelReportIssue_WorksFromDiffView(t *testing.T) {
+	m := makeModel("a.go")
+	m = sendKey(m, "l") // focus diff
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "Opening")
+	assert.NotNil(t, cmd, "should return a command to open the URL")
+}
+
 func TestModelComment_CommentInputBlocksOtherKeys(t *testing.T) {
 	m := makeModelWithDiff("foo.go", []git.Line{
 		{Type: git.LineAdded, Content: "hello", NewNum: 1},


### PR DESCRIPTION
## Summary
- Press `!` from any panel to open the GitHub new issue page in the browser
- Shows "Opening ..." status message with auto-clear
- Added to Global key bindings (visible in `?` help and `--help`)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)