### PR TITLE
Add file review mode for arbitrary files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ A terminal UI for reviewing local git changes and sending feedback to Claude Cod
 
 ## Project Overview
 
-`revise` is a Go TUI application built with [Bubbletea](https://github.com/charmbracelet/bubbletea) and [Lipgloss](https://github.com/charmbracelet/lipgloss). It provides a split-pane interface for reviewing git diffs: a file list on the left and a diff viewer on the right.
+`revise` is a Go TUI application built with [Bubbletea](https://github.com/charmbracelet/bubbletea) and [Lipgloss](https://github.com/charmbracelet/lipgloss). It provides a split-pane interface for reviewing git diffs: a file list on the left and a diff viewer on the right. It can also review arbitrary files with `revise <file>`.
 
 ## Tech Stack
 
@@ -68,6 +68,17 @@ make install  # go install
 make test     # go test ./...
 make clean    # remove binary
 ```
+
+### File Review Mode
+
+`revise <file>` opens a file in read-only review mode:
+- All lines shown as context (no diff coloring, no hunk headers)
+- Starts fullscreen with diff view focused
+- Comments (`c`/`Enter`/`d`) and export (`e`) work normally
+- Git-specific features disabled: stage/unstage/discard, mode cycling, context lines
+- Status bar shows the filename instead of mode slider
+- Help overlay (`?`) hides git-specific bindings
+- Constructed via `ui.NewFileReview(diff, filePath)` with a synthetic `git.Diff`
 
 ## Architecture
 
@@ -140,7 +151,7 @@ Three diff components displayed left-to-right: **Branch · Staged · Unstaged**.
 
 ### Keyboard Bindings
 
-All bindings are defined in `internal/ui/keys.go` (`allBindings`) and used to generate both the in-app help overlay (`?`) and the `--help` CLI output. This is the single source of truth — do not define bindings elsewhere.
+All bindings are defined in `internal/ui/keys.go` (`allBindings`) and used to generate both the in-app help overlay (`?`) and the `--help` CLI output. This is the single source of truth — do not define bindings elsewhere. Bindings have a `GitOnly` flag — when true, they are hidden in file review mode help and disabled in input handling.
 
 Bubbletea maps the Escape key to the string `"esc"` (not `"escape"`) — use `case "esc":` in switch statements.
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -372,6 +372,11 @@ func formatGutter(l git.Line) string {
 }
 
 func renderHunkHeader(h git.Hunk) string {
+	// Empty header means no hunk header should be displayed (e.g. file review mode).
+	if h.Header == "" && h.Source == "" {
+		return ""
+	}
+
 	header := hunkContext(h.Header)
 
 	style := hunkStyle

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -6,13 +6,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func renderHelp(width, height int) string {
+func renderHelp(width, height int, groups []BindingGroup) string {
 	var b strings.Builder
 
 	b.WriteString(fileStyle.Render("Keyboard Shortcuts"))
 	b.WriteString("\n")
 
-	for _, group := range allBindings {
+	for _, group := range groups {
 		b.WriteString("\n")
 		b.WriteString(helpDescStyle.Render(group.Name) + "\n")
 		for _, bind := range group.Bindings {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -2,8 +2,9 @@ package ui
 
 // Binding describes a keyboard shortcut for display in help.
 type Binding struct {
-	Key  string
-	Desc string
+	Key     string
+	Desc    string
+	GitOnly bool // true if this binding only applies to git diff mode
 }
 
 // BindingGroup is a named group of keyboard shortcuts.
@@ -16,46 +17,63 @@ type BindingGroup struct {
 // The help overlay and --help output are generated from this list.
 var allBindings = []BindingGroup{
 	{"General", []Binding{
-		{"← (h)", "Focus file list"},
-		{"→ (l)", "Focus diff view"},
-		{"n/N", "Next/prev file"},
-		{"Tab/S-Tab", "Cycle diff mode"},
-		{"f", "Toggle fullscreen diff"},
-		{"Esc", "Back to file list"},
-		{"?", "Toggle help"},
-		{"q", "Quit"},
+		{"← (h)", "Focus file list", false},
+		{"→ (l)", "Focus diff view", false},
+		{"n/N", "Next/prev file", false},
+		{"Tab/S-Tab", "Cycle diff mode", true},
+		{"f", "Toggle fullscreen diff", false},
+		{"Esc", "Back to file list", false},
+		{"?", "Toggle help", false},
+		{"q", "Quit", false},
 	}},
 	{"File List", []Binding{
-		{"j/k, ↑/↓", "Navigate files"},
-		{"Enter", "Select file and focus diff"},
-		{"s", "Stage file"},
-		{"u", "Unstage file"},
-		{"D", "Discard file"},
+		{"j/k, ↑/↓", "Navigate files", false},
+		{"Enter", "Select file and focus diff", false},
+		{"s", "Stage file", true},
+		{"u", "Unstage file", true},
+		{"D", "Discard file", true},
 	}},
 	{"Diff View", []Binding{
-		{"j/k, ↑/↓", "Move cursor"},
-		{"}/{ (]/[)", "Next/prev hunk"},
-		{"+/-", "More/fewer context lines"},
-		{"w", "Toggle hide whitespace"},
-		{"g/G", "Top/bottom"},
-		{"Fn+↓/↑", "Page down/up"},
-		{"Enter/c", "Add/edit comment on line"},
-		{"d", "Delete comment on line"},
-		{"s/S", "Stage hunk/file"},
-		{"u/U", "Unstage hunk/file"},
-		{"D", "Discard hunk"},
+		{"j/k, ↑/↓", "Move cursor", false},
+		{"}/{ (]/[)", "Next/prev hunk", false},
+		{"+/-", "More/fewer context lines", true},
+		{"w", "Toggle hide whitespace", false},
+		{"g/G", "Top/bottom", false},
+		{"Fn+↓/↑", "Page down/up", false},
+		{"Enter/c", "Add/edit comment on line", false},
+		{"d", "Delete comment on line", false},
+		{"s/S", "Stage hunk/file", true},
+		{"u/U", "Unstage hunk/file", true},
+		{"D", "Discard hunk", true},
 	}},
 	{"Global", []Binding{
-		{"e", "Export comments to clipboard"},
-		{"!", "Report issue on GitHub"},
+		{"e", "Export comments to clipboard", false},
+		{"!", "Report issue on GitHub", false},
 	}},
 	{"Comment Input", []Binding{
-		{"Enter", "Save comment"},
-		{"Esc", "Cancel"},
+		{"Enter", "Save comment", false},
+		{"Esc", "Cancel", false},
 	}},
 }
 
 // BindingGroups returns all keyboard shortcut groups.
 func BindingGroups() []BindingGroup {
 	return allBindings
+}
+
+// FileReviewBindingGroups returns binding groups filtered for file review mode.
+func FileReviewBindingGroups() []BindingGroup {
+	var groups []BindingGroup
+	for _, g := range allBindings {
+		var bindings []Binding
+		for _, b := range g.Bindings {
+			if !b.GitOnly {
+				bindings = append(bindings, b)
+			}
+		}
+		if len(bindings) > 0 {
+			groups = append(groups, BindingGroup{Name: g.Name, Bindings: bindings})
+		}
+	}
+	return groups
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -74,6 +74,36 @@ type Model struct {
 	confirmDiscard    bool    // waiting for confirmation to discard
 	confirmMsg        string  // message shown in the discard confirmation modal
 	pendingDiscardCmd tea.Cmd // the discard command to run on confirmation
+
+	fileReviewMode bool   // true when reviewing a file (not a git diff)
+	fileReviewPath string // filename shown in status bar
+}
+
+// NewFileReview creates a Model for reviewing a file (not a git diff).
+// It starts in fullscreen with focus on the diff view.
+func NewFileReview(diff *git.Diff, filePath string) Model {
+	fl := newFileListModel(diff.Files)
+	dv := newDiffViewModel()
+
+	c := make(comments)
+	dv.comments = c
+	fl.comments = c
+
+	if len(diff.Files) > 0 {
+		dv.setFile(&diff.Files[0])
+	}
+
+	return Model{
+		diff:           diff,
+		fileList:       fl,
+		diffView:       dv,
+		focus:          focusDiffView,
+		fullscreen:     true,
+		comments:       c,
+		mode:           ModeStaged,
+		fileReviewMode: true,
+		fileReviewPath: filePath,
+	}
 }
 
 func New(diff *git.Diff, onDefaultBranch bool) Model {
@@ -183,9 +213,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "tab":
+			if m.fileReviewMode {
+				return m, nil
+			}
 			m.cycleMode(+1)
 			return m, m.loadDiff()
 		case "shift+tab":
+			if m.fileReviewMode {
+				return m, nil
+			}
 			m.cycleMode(-1)
 			return m, m.loadDiff()
 
@@ -204,9 +240,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Adjust context lines
 		case "+", "=":
+			if m.fileReviewMode {
+				return m, nil
+			}
 			m.contextLines++
 			return m, m.loadDiff()
 		case "-", "_":
+			if m.fileReviewMode {
+				return m, nil
+			}
 			if m.contextLines > 0 {
 				m.contextLines--
 				return m, m.loadDiff()
@@ -399,14 +441,23 @@ func (m Model) updateFileList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.syncSelectedFile()
 		m.focus = focusDiffView
 	case "s", "S":
+		if m.fileReviewMode {
+			return m, nil
+		}
 		if cmd := m.stageCurrentFile(); cmd != nil {
 			return m, cmd
 		}
 	case "u", "U":
+		if m.fileReviewMode {
+			return m, nil
+		}
 		if cmd := m.unstageCurrentFile(); cmd != nil {
 			return m, cmd
 		}
 	case "D":
+		if m.fileReviewMode {
+			return m, nil
+		}
 		if cmd := m.discardCurrentFile(); cmd != nil {
 			return m, cmd
 		}
@@ -439,22 +490,37 @@ func (m Model) updateDiffView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "d":
 		m.deleteCommentAtCursor()
 	case "s":
+		if m.fileReviewMode {
+			return m, nil
+		}
 		if cmd := m.stageCurrentHunk(); cmd != nil {
 			return m, cmd
 		}
 	case "u":
+		if m.fileReviewMode {
+			return m, nil
+		}
 		if cmd := m.unstageCurrentHunk(); cmd != nil {
 			return m, cmd
 		}
 	case "D":
+		if m.fileReviewMode {
+			return m, nil
+		}
 		if cmd := m.discardCurrentHunk(); cmd != nil {
 			return m, cmd
 		}
 	case "S":
+		if m.fileReviewMode {
+			return m, nil
+		}
 		if cmd := m.stageCurrentFile(); cmd != nil {
 			return m, cmd
 		}
 	case "U":
+		if m.fileReviewMode {
+			return m, nil
+		}
 		if cmd := m.unstageCurrentFile(); cmd != nil {
 			return m, cmd
 		}
@@ -930,7 +996,11 @@ func (m Model) View() string {
 	}
 
 	if m.showHelp {
-		return renderHelp(m.width, m.height)
+		groups := allBindings
+		if m.fileReviewMode {
+			groups = FileReviewBindingGroups()
+		}
+		return renderHelp(m.width, m.height, groups)
 	}
 
 	statusBar := m.renderStatusBar()
@@ -940,7 +1010,11 @@ func (m Model) View() string {
 		panels := m.diffView.render(true, m.contextLines, m.hideWhitespace)
 		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
 	} else {
-		left := m.fileList.render(m.focus == focusFileList, m.renderModeSlider())
+		slider := m.renderModeSlider()
+		if m.fileReviewMode {
+			slider = m.fileReviewPath
+		}
+		left := m.fileList.render(m.focus == focusFileList, slider)
 		right := m.diffView.render(m.focus == focusDiffView, m.contextLines, m.hideWhitespace)
 		panels := lipgloss.JoinHorizontal(lipgloss.Top, left, " ", right)
 		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -55,6 +55,125 @@ func focusDiffAndMoveTo(m Model, n int) Model {
 	return m
 }
 
+// makeFileReviewModel creates a file review mode model with context lines.
+func makeFileReviewModel(lines []git.Line) Model {
+	diff := &git.Diff{
+		Files: []git.FileDiff{{
+			Path:   "test.md",
+			Status: git.StatusModified,
+			Hunks:  []git.Hunk{{Lines: lines}},
+		}},
+	}
+	m := NewFileReview(diff, "test.md")
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	return updated.(Model)
+}
+
+func TestFileReviewMode_StartsFullscreenWithDiffFocus(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	assert.True(t, m.fullscreen)
+	assert.Equal(t, focusDiffView, m.focus)
+	assert.True(t, m.fileReviewMode)
+}
+
+func TestFileReviewMode_TabIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	mode := m.mode
+	m = sendSpecialKey(m, tea.KeyTab)
+	assert.Equal(t, mode, m.mode)
+}
+
+func TestFileReviewMode_PlusMinusAreNoops(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	ctx := m.contextLines
+	m = sendKey(m, "+")
+	assert.Equal(t, ctx, m.contextLines)
+	m = sendKey(m, "-")
+	assert.Equal(t, ctx, m.contextLines)
+}
+
+func TestFileReviewMode_StageKeyIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestFileReviewMode_UnstageKeyIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestFileReviewMode_DiscardKeyIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+	assert.False(t, m.confirmDiscard)
+}
+
+func TestFileReviewMode_CommentStillWorks(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	require.NotNil(t, m.diffView.cursorRef())
+	m = sendKey(m, "c")
+	assert.True(t, m.commentInputActive)
+}
+
+func TestFileReviewMode_StatusBarShowsFilename(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	status := m.renderStatusBar()
+	assert.Contains(t, status, "test.md")
+	assert.NotContains(t, status, "Branch")
+	assert.NotContains(t, status, "Staged")
+}
+
+func TestFileReviewMode_HelpOmitsGitBindings(t *testing.T) {
+	groups := FileReviewBindingGroups()
+	for _, g := range groups {
+		for _, b := range g.Bindings {
+			assert.False(t, b.GitOnly, "help should not include git-only binding: %s", b.Key)
+		}
+	}
+	// Verify some git-only bindings are filtered out
+	allKeys := ""
+	for _, g := range groups {
+		for _, b := range g.Bindings {
+			allKeys += b.Key + " "
+		}
+	}
+	assert.NotContains(t, allKeys, "Tab/S-Tab")
+	assert.NotContains(t, allKeys, "+/-")
+}
+
+func TestFileReviewMode_NoHunkHeaderRendered(t *testing.T) {
+	// A hunk with empty header and no source should render no header line
+	h := git.Hunk{Lines: []git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	}}
+	header := renderHunkHeader(h)
+	assert.Empty(t, header)
+}
+
 func TestModelInitialFocus(t *testing.T) {
 	m := makeModel("a.go", "b.go")
 	assert.Equal(t, focusFileList, m.focus)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
@@ -27,6 +28,23 @@ func main() {
 	if *versionFlag {
 		fmt.Println("revise", version)
 		os.Exit(0)
+	}
+
+	// File review mode: positional argument
+	if args := flag.Args(); len(args) > 0 {
+		filePath := args[0]
+		diff, err := buildFileDiff(filePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		m := ui.NewFileReview(diff, filePath)
+		p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+		if _, err := p.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	if !git.IsGitRepo() {
@@ -75,10 +93,43 @@ func main() {
 	}
 }
 
+// buildFileDiff reads a file and returns a synthetic Diff for file review mode.
+func buildFileDiff(filePath string) (*git.Diff, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var lines []git.Line
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		lines = append(lines, git.Line{
+			Type:    git.LineContext,
+			Content: scanner.Text(),
+			OldNum:  lineNum,
+			NewNum:  lineNum,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return &git.Diff{
+		Files: []git.FileDiff{{
+			Path:   filePath,
+			Status: git.StatusModified,
+			Hunks:  []git.Hunk{{Lines: lines}},
+		}},
+	}, nil
+}
+
 func printHelp() {
 	fmt.Println(`revise - Review local git changes
 
-Usage: revise [flags]
+Usage: revise [flags] [file]
 
 Flags:
   --help      Show this help


### PR DESCRIPTION
## Summary
- `revise <file>` opens any file in a read-only review mode with full comment support
- All lines shown as context (no diff coloring, no hunk headers)
- Starts fullscreen with diff view focused
- Git-specific features (stage/unstage/discard, mode cycling, context lines) disabled
- Status bar shows filename; help overlay hides git-only bindings

## Test plan
- [ ] `go test ./...` passes (11 new tests for file review mode)
- [ ] `revise CLAUDE.md` shows file content with line numbers, can add comments with `c`, export with `e`
- [ ] `revise` (no args) — existing git diff behavior unchanged
- [ ] `revise nonexistent.txt` shows error message
- [ ] Stage/unstage/discard keys are no-ops in file review mode