### PR TITLE
Add toggle to hide whitespace changes

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -86,6 +86,19 @@ func RawDiffBetween(from, to string, contextLines int) (string, error) {
 	return string(out), nil
 }
 
+// RawDiffBetweenIgnoreWhitespace returns the raw unified diff between two refs, ignoring whitespace.
+func RawDiffBetweenIgnoreWhitespace(from, to string, contextLines int) (string, error) {
+	args := []string{"diff", "-w", fmt.Sprintf("-U%d", contextLines), from, to}
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("git diff failed: %s", string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("git diff: %w", err)
+	}
+	return string(out), nil
+}
+
 // StagedDiff returns the raw diff of staged changes.
 func StagedDiff(contextLines int) (string, error) {
 	args := []string{"diff", fmt.Sprintf("-U%d", contextLines), "--cached"}
@@ -96,9 +109,29 @@ func StagedDiff(contextLines int) (string, error) {
 	return string(out), nil
 }
 
+// StagedDiffIgnoreWhitespace returns the raw diff of staged changes, ignoring whitespace.
+func StagedDiffIgnoreWhitespace(contextLines int) (string, error) {
+	args := []string{"diff", "-w", fmt.Sprintf("-U%d", contextLines), "--cached"}
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("git diff --cached: %w", err)
+	}
+	return string(out), nil
+}
+
 // UnstagedDiff returns the raw diff of unstaged changes.
 func UnstagedDiff(contextLines int) (string, error) {
 	args := []string{"diff", fmt.Sprintf("-U%d", contextLines)}
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("git diff: %w", err)
+	}
+	return string(out), nil
+}
+
+// UnstagedDiffIgnoreWhitespace returns the raw diff of unstaged changes, ignoring whitespace.
+func UnstagedDiffIgnoreWhitespace(contextLines int) (string, error) {
+	args := []string{"diff", "-w", fmt.Sprintf("-U%d", contextLines)}
 	out, err := exec.Command("git", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("git diff: %w", err)
@@ -220,6 +253,54 @@ func resolveMergeBase() (string, error) {
 	return mergeBase, nil
 }
 
+// BranchDiffOptions returns BranchDiff with optional whitespace ignoring.
+func BranchDiffOptions(contextLines int, hideWhitespace bool) (*Diff, error) {
+	if !hideWhitespace {
+		return BranchDiff(contextLines)
+	}
+
+	mergeBase, err := resolveMergeBase()
+	if err != nil {
+		return nil, err
+	}
+
+	head, err := CurrentRef()
+	if err != nil {
+		return nil, err
+	}
+
+	var raw string
+	if mergeBase == head {
+		branch, err := DefaultBranch()
+		if err != nil {
+			return nil, err
+		}
+		remote := RemoteName()
+		if remote == "" {
+			return nil, fmt.Errorf("no remote configured")
+		}
+		raw, err = RawDiffBetweenIgnoreWhitespace(head, remote+"/"+branch, contextLines)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		raw, err = RawDiffBetweenIgnoreWhitespace(mergeBase, "HEAD", contextLines)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	diff := Parse(raw)
+	tagHunks(diff.Files, SourceBranch)
+
+	wtDiff, err := WorkingTreeDiffOptions(contextLines, true)
+	if err != nil {
+		return nil, err
+	}
+	diff.Files = mergeFileDiffs(diff.Files, wtDiff.Files)
+	return diff, nil
+}
+
 // BranchDiff returns the merge-base diff merged with all working tree changes.
 // This is the broadest view — committed + staged + unstaged + untracked.
 // On the default branch behind the remote, it shows the remote's changes.
@@ -269,6 +350,23 @@ func BranchDiff(contextLines int) (*Diff, error) {
 	return diff, nil
 }
 
+// StagedOnlyDiffOptions returns only staged changes, optionally ignoring whitespace.
+func StagedOnlyDiffOptions(contextLines int, hideWhitespace bool) (*Diff, error) {
+	var raw string
+	var err error
+	if hideWhitespace {
+		raw, err = StagedDiffIgnoreWhitespace(contextLines)
+	} else {
+		raw, err = StagedDiff(contextLines)
+	}
+	if err != nil {
+		return nil, err
+	}
+	diff := Parse(raw)
+	tagHunks(diff.Files, SourceStaged)
+	return diff, nil
+}
+
 // StagedOnlyDiff returns only staged changes.
 func StagedOnlyDiff(contextLines int) (*Diff, error) {
 	raw, err := StagedDiff(contextLines)
@@ -277,6 +375,28 @@ func StagedOnlyDiff(contextLines int) (*Diff, error) {
 	}
 	diff := Parse(raw)
 	tagHunks(diff.Files, SourceStaged)
+	return diff, nil
+}
+
+// UnstagedOnlyDiffOptions returns unstaged changes + untracked files, optionally ignoring whitespace.
+func UnstagedOnlyDiffOptions(contextLines int, hideWhitespace bool) (*Diff, error) {
+	var raw string
+	var err error
+	if hideWhitespace {
+		raw, err = UnstagedDiffIgnoreWhitespace(contextLines)
+	} else {
+		raw, err = UnstagedDiff(contextLines)
+	}
+	if err != nil {
+		return nil, err
+	}
+	diff := Parse(raw)
+	tagHunks(diff.Files, SourceUnstaged)
+	untracked, err := UntrackedFiles()
+	if err != nil {
+		return nil, err
+	}
+	diff.Files = append(diff.Files, untracked...)
 	return diff, nil
 }
 
@@ -301,7 +421,12 @@ func UnstagedOnlyDiff(contextLines int) (*Diff, error) {
 
 // WorkingTreeDiff returns staged + unstaged + untracked changes.
 func WorkingTreeDiff(contextLines int) (*Diff, error) {
-	return getWorkingTreeDiff(contextLines)
+	return getWorkingTreeDiff(contextLines, false)
+}
+
+// WorkingTreeDiffOptions returns staged + unstaged + untracked changes, optionally ignoring whitespace.
+func WorkingTreeDiffOptions(contextLines int, hideWhitespace bool) (*Diff, error) {
+	return getWorkingTreeDiff(contextLines, hideWhitespace)
 }
 
 // GetDiff returns a parsed Diff for the current branch vs the default branch.
@@ -329,14 +454,27 @@ func GetDiff() (*Diff, error) {
 }
 
 // getWorkingTreeDiff returns staged + unstaged + untracked changes.
-func getWorkingTreeDiff(contextLines int) (*Diff, error) {
-	stagedRaw, err := StagedDiff(contextLines)
-	if err != nil {
-		return nil, err
-	}
-	unstagedRaw, err := UnstagedDiff(contextLines)
-	if err != nil {
-		return nil, err
+func getWorkingTreeDiff(contextLines int, hideWhitespace bool) (*Diff, error) {
+	var stagedRaw, unstagedRaw string
+	var err error
+	if hideWhitespace {
+		stagedRaw, err = StagedDiffIgnoreWhitespace(contextLines)
+		if err != nil {
+			return nil, err
+		}
+		unstagedRaw, err = UnstagedDiffIgnoreWhitespace(contextLines)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		stagedRaw, err = StagedDiff(contextLines)
+		if err != nil {
+			return nil, err
+		}
+		unstagedRaw, err = UnstagedDiff(contextLines)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	staged := Parse(stagedRaw)

--- a/internal/git/diff_integration_test.go
+++ b/internal/git/diff_integration_test.go
@@ -656,6 +656,34 @@ func TestUntrackedFiles_TaggedAsUnstaged(t *testing.T) {
 	assert.Equal(t, SourceUnstaged, f.Hunks[0].Source)
 }
 
+// ============================================================================
+// Hide whitespace
+// ============================================================================
+
+func TestUnstagedDiff_HideWhitespace(t *testing.T) {
+	r := baseRepo(t)
+	// Add only whitespace changes
+	r.WriteFile("base.go", "package main\n\nfunc base() {  }\n")
+
+	raw, err := UnstagedDiff(DefaultContextLines)
+	require.NoError(t, err)
+	assert.NotEmpty(t, raw, "without -w, whitespace changes should appear")
+
+	rawW, err := UnstagedDiffIgnoreWhitespace(DefaultContextLines)
+	require.NoError(t, err)
+	assert.Empty(t, rawW, "with -w, whitespace-only changes should be hidden")
+}
+
+func TestWorkingTreeDiff_HideWhitespace(t *testing.T) {
+	r := baseRepo(t)
+	// Only whitespace change
+	r.WriteFile("base.go", "package main\n\nfunc base() {  }\n")
+
+	diff, err := WorkingTreeDiffOptions(DefaultContextLines, true)
+	require.NoError(t, err)
+	assert.Empty(t, diff.Files, "whitespace-only changes should be hidden with -w")
+}
+
 func TestGetDiff_FeatureBranch_RenamedFile(t *testing.T) {
 	r := NewTestRepo(t)
 	r.WriteFile("old.go", "package main\n\nfunc old() {}\n")

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -36,6 +36,7 @@ var allBindings = []BindingGroup{
 		{"j/k, ↑/↓", "Move cursor"},
 		{"}/{ (]/[)", "Next/prev hunk"},
 		{"+/-", "More/fewer context lines"},
+		{"w", "Toggle hide whitespace"},
 		{"g/G", "Top/bottom"},
 		{"Fn+↓/↑", "Page down/up"},
 		{"Enter/c", "Add/edit comment on line"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -60,6 +60,7 @@ type Model struct {
 	mode            DiffMode
 	onDefaultBranch bool
 	contextLines    int
+	hideWhitespace  bool
 
 	comments           comments
 	commentInputActive bool
@@ -175,6 +176,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "N":
 			m.prevFile()
 			return m, nil
+
+		// Toggle hide whitespace
+		case "w":
+			m.hideWhitespace = !m.hideWhitespace
+			return m, m.loadDiff()
 
 		// Adjust context lines
 		case "+", "=":
@@ -767,16 +773,17 @@ func (m *Model) cycleMode(direction int) {
 func (m *Model) loadDiff() tea.Cmd {
 	mode := m.mode
 	ctx := m.contextLines
+	hideWS := m.hideWhitespace
 	return func() tea.Msg {
 		var diff *git.Diff
 		var err error
 		switch mode {
 		case ModeBranch:
-			diff, err = git.BranchDiff(ctx)
+			diff, err = git.BranchDiffOptions(ctx, hideWS)
 		case ModeStaged:
-			diff, err = git.WorkingTreeDiff(ctx)
+			diff, err = git.WorkingTreeDiffOptions(ctx, hideWS)
 		case ModeUnstaged:
-			diff, err = git.UnstagedOnlyDiff(ctx)
+			diff, err = git.UnstagedOnlyDiffOptions(ctx, hideWS)
 		}
 		return diffLoadedMsg{diff: diff, err: err}
 	}
@@ -834,7 +841,11 @@ func (m Model) renderModeSlider() string {
 	}
 
 	ctx := fmt.Sprintf("  +/-: context (%d)", m.contextLines)
-	return result + modeInactiveStyle.Render("  Tab: switch") + modeInactiveStyle.Render(ctx)
+	extra := ""
+	if m.hideWhitespace {
+		extra = "  " + modeActiveStyle.Render("w: whitespace hidden")
+	}
+	return result + modeInactiveStyle.Render("  Tab: switch") + modeInactiveStyle.Render(ctx) + extra
 }
 
 func (m Model) renderStatusBar() string {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -858,6 +858,24 @@ func TestModelFileList_D_BranchOnlyFile_ShowsError(t *testing.T) {
 	assert.False(t, m.confirmDiscard)
 }
 
+// --- Hide whitespace tests ---
+
+func TestModelW_TogglesHideWhitespace(t *testing.T) {
+	m := makeModel("a.go")
+	assert.False(t, m.hideWhitespace)
+	m = sendKey(m, "w")
+	assert.True(t, m.hideWhitespace)
+	m = sendKey(m, "w")
+	assert.False(t, m.hideWhitespace)
+}
+
+func TestModeSlider_ShowsWhitespaceIndicator(t *testing.T) {
+	m := makeModel("a.go")
+	m.hideWhitespace = true
+	slider := m.renderModeSlider()
+	assert.Contains(t, slider, "w: whitespace hidden")
+}
+
 func TestRenderStatusBar_FileListNoPaneTotals(t *testing.T) {
 	m := makeModelWithDiff("foo.go", []git.Line{
 		{Type: git.LineAdded, Content: "a", NewNum: 1},


### PR DESCRIPTION
## Summary
- Add `w` key binding to toggle hiding whitespace-only changes in the diff view
- Uses `git diff -w` flag, threaded through all diff modes (Branch, Staged, Unstaged)
- Shows "w: whitespace hidden" indicator in the mode slider when active

Closes #18

## Test plan
- [x] `make test` passes
- [x] Integration test verifying whitespace-only changes are hidden with `-w`
- [x] Unit tests for `w` key toggle and slider indicator
- [ ] Manual test: make whitespace-only changes, toggle `w` to verify they disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)