### PR TITLE
Cache untracked file reads for faster +/-

### DIFF
--- a/internal/git/untracked.go
+++ b/internal/git/untracked.go
@@ -5,16 +5,42 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
+	"time"
 )
 
+// untrackedCache caches untracked file diffs to avoid re-reading large files
+// on every context line change. The cache is invalidated when the untracked
+// file list changes (different paths) or after a short TTL.
+var untrackedCache struct {
+	mu       sync.Mutex
+	files    []FileDiff
+	pathsKey string // sorted paths joined, used to detect changes
+	time     time.Time
+}
+
+const untrackedCacheTTL = 2 * time.Second
+
 // UntrackedFiles returns synthetic FileDiff entries for untracked files.
+// Results are cached to avoid re-reading file contents when only context
+// lines change (the bottleneck identified in issue #35).
 func UntrackedFiles() ([]FileDiff, error) {
 	out, err := exec.Command("git", "ls-files", "--others", "--exclude-standard").Output()
 	if err != nil {
 		return nil, err
 	}
 
-	paths := strings.Split(strings.TrimSpace(string(out)), "\n")
+	rawPaths := strings.TrimSpace(string(out))
+
+	untrackedCache.mu.Lock()
+	defer untrackedCache.mu.Unlock()
+
+	now := time.Now()
+	if rawPaths == untrackedCache.pathsKey && now.Sub(untrackedCache.time) < untrackedCacheTTL {
+		return untrackedCache.files, nil
+	}
+
+	paths := strings.Split(rawPaths, "\n")
 	var files []FileDiff
 
 	for _, path := range paths {
@@ -59,5 +85,16 @@ func UntrackedFiles() ([]FileDiff, error) {
 		})
 	}
 
+	untrackedCache.files = files
+	untrackedCache.pathsKey = rawPaths
+	untrackedCache.time = now
+
 	return files, nil
+}
+
+// InvalidateUntrackedCache forces the next UntrackedFiles call to re-read files.
+func InvalidateUntrackedCache() {
+	untrackedCache.mu.Lock()
+	untrackedCache.time = time.Time{}
+	untrackedCache.mu.Unlock()
 }


### PR DESCRIPTION
## Summary
- Cache UntrackedFiles() results for 2 seconds with path-based invalidation
- Untracked file diffs do not depend on context line count, so re-reading file contents on every +/- press was unnecessary I/O
- Cache auto-invalidates when the untracked file list changes (new/removed files)

Closes #35

## Test plan
- [x] make test passes
- [ ] Open a repo with a large untracked file, press +/- rapidly — should be fast now

Generated with [Claude Code](https://claude.com/claude-code)