### PR TITLE
Fix branch mode on checkout from default

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -22,8 +22,9 @@ type hunkApplyMsg struct {
 
 // diffLoadedMsg is sent when an async diff load completes.
 type diffLoadedMsg struct {
-	diff *git.Diff
-	err  error
+	diff            *git.Diff
+	err             error
+	onDefaultBranch bool
 }
 
 // DiffMode represents which diff view is active.
@@ -294,6 +295,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
 		}
 		m.diff = msg.diff
+
+		// Update default-branch status so Branch mode becomes
+		// available (or unavailable) dynamically.
+		m.onDefaultBranch = msg.onDefaultBranch
+		// If the current mode is no longer valid, clamp it.
+		modes := m.availableModes()
+		modeValid := false
+		for _, am := range modes {
+			if am == m.mode {
+				modeValid = true
+				break
+			}
+		}
+		if !modeValid {
+			m.mode = modes[0]
+		}
+
 		selectedPath := ""
 		if f := m.fileList.selectedFile(); f != nil {
 			selectedPath = f.Path
@@ -775,6 +793,10 @@ func (m *Model) loadDiff() tea.Cmd {
 	ctx := m.contextLines
 	hideWS := m.hideWhitespace
 	return func() tea.Msg {
+		// Re-check whether we're on the default branch so the UI can
+		// enable/disable Branch mode dynamically (e.g. after git checkout -b).
+		onDefault, _ := git.IsOnDefaultBranch()
+
 		var diff *git.Diff
 		var err error
 		switch mode {
@@ -785,7 +807,7 @@ func (m *Model) loadDiff() tea.Cmd {
 		case ModeUnstaged:
 			diff, err = git.UnstagedOnlyDiffOptions(ctx, hideWS)
 		}
-		return diffLoadedMsg{diff: diff, err: err}
+		return diffLoadedMsg{diff: diff, err: err, onDefaultBranch: onDefault}
 	}
 }
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -359,6 +359,61 @@ func TestNewModel_DefaultBranch_StartsOnStaged(t *testing.T) {
 	assert.Equal(t, ModeStaged, m.mode)
 }
 
+func TestDiffRefresh_UpdatesOnDefaultBranch(t *testing.T) {
+	// Start on default branch — Branch mode is not available
+	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+
+	require.True(t, m.onDefaultBranch)
+	require.Equal(t, ModeStaged, m.mode)
+	require.Equal(t, []DiffMode{ModeStaged, ModeUnstaged}, m.availableModes())
+
+	// Simulate a diff refresh that reports we're no longer on the default branch
+	// (e.g., user ran `git checkout -b feature` while the app was running)
+	updated, _ = m.Update(diffLoadedMsg{
+		diff:            &git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}},
+		onDefaultBranch: false,
+	})
+	m = updated.(Model)
+
+	assert.False(t, m.onDefaultBranch)
+	assert.Equal(t, []DiffMode{ModeBranch, ModeStaged, ModeUnstaged}, m.availableModes())
+}
+
+func TestDiffRefresh_SwitchesToFeatureBranch_KeepsCurrentMode(t *testing.T) {
+	// Start on default branch in ModeStaged
+	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	require.Equal(t, ModeStaged, m.mode)
+
+	// Switch to feature branch — mode should stay ModeStaged (still valid)
+	updated, _ = m.Update(diffLoadedMsg{
+		diff:            &git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}},
+		onDefaultBranch: false,
+	})
+	m = updated.(Model)
+
+	assert.Equal(t, ModeStaged, m.mode, "should keep current mode when it's still valid")
+}
+
+func TestDiffRefresh_SwitchesToDefaultBranch_ClampsMode(t *testing.T) {
+	// Start on feature branch in ModeBranch
+	m := makeModel("a.go")
+	require.Equal(t, ModeBranch, m.mode)
+
+	// Switch to default branch — ModeBranch is no longer available, should clamp to ModeStaged
+	updated, _ := m.Update(diffLoadedMsg{
+		diff:            &git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}},
+		onDefaultBranch: true,
+	})
+	m = updated.(Model)
+
+	assert.True(t, m.onDefaultBranch)
+	assert.Equal(t, ModeStaged, m.mode, "should clamp to ModeStaged when Branch is no longer available")
+}
+
 // --- Mode slider rendering tests ---
 
 func TestModeSlider_FeatureBranch_BranchMode_AllLit(t *testing.T) {


### PR DESCRIPTION
## Summary
- Re-check IsOnDefaultBranch on every diff reload so Branch mode becomes available after git checkout -b
- Clamp mode when switching from default to feature branch (or vice versa)

Closes #57

## Test plan
- [x] Unit tests for dynamic mode availability
- [ ] Start on main, git checkout -b feature, Tab should now cycle through Branch mode

Generated with [Claude Code](https://claude.com/claude-code)