### PR TITLE
Add staged-only diff mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,19 +102,20 @@ internal/
 
 ### Diff Strategy
 
-Three diff components displayed left-to-right: **Branch · Staged · Unstaged**. Modes are cumulative — narrower modes drop from the left, Unstaged is always included. Tab/Shift+Tab cycles through modes.
+Three diff components displayed left-to-right: **Branch · Staged · Unstaged**. Tab/Shift+Tab cycles through modes. Broader modes light more components; `ModeStagedOnly` and `ModeUnstaged` each light only their respective component.
 
 | Mode | Slider | What it shows |
 |------|--------|--------------|
-| **ModeBranch** | **Branch·Staged·Unstaged** | committed + staged + unstaged + untracked (broadest, default) — skipped on default branch |
-| **ModeStaged** | Branch·**Staged·Unstaged** | staged + unstaged + untracked |
-| **ModeUnstaged** | Branch·Staged·**Unstaged** | unstaged + untracked only (narrowest) |
+| **ModeBranch** | **Branch+Staged+Unstaged** | committed + staged + unstaged + untracked (broadest, default) — skipped on default branch |
+| **ModeStaged** | Branch **Staged+Unstaged** | staged + unstaged + untracked |
+| **ModeStagedOnly** | Branch **Staged** Unstaged | staged only (no unstaged or untracked) |
+| **ModeUnstaged** | Branch Staged **Unstaged** | unstaged + untracked only (narrowest) |
 
 - Default mode: ModeBranch on feature branches (broadest), ModeStaged on default branch
 - Default branch is auto-detected via `origin/main`, `origin/master`, then `git symbolic-ref refs/remotes/origin/HEAD`
 - Working tree changes for the same path replace branch diff entries (latest state wins)
 - `IsOnDefaultBranch()` checks if merge-base == HEAD
-- Per-mode git functions: `BranchDiff()`, `WorkingTreeDiff()`, `UnstagedOnlyDiff()`, `StagedOnlyDiff()` (reserved for future use)
+- Per-mode git functions: `BranchDiff()`, `WorkingTreeDiff()`, `StagedOnlyDiff()`, `UnstagedOnlyDiff()`
 - Untracked files are merged into "Unstaged" — no separate untracked mode
 
 ### UI Layout

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -33,9 +33,10 @@ type diffLoadedMsg struct {
 type DiffMode int
 
 const (
-	ModeBranch   DiffMode = iota // committed + staged + unstaged + untracked (broadest, feature branch only)
-	ModeStaged                   // staged + unstaged + untracked
-	ModeUnstaged                 // unstaged + untracked only (narrowest)
+	ModeBranch    DiffMode = iota // committed + staged + unstaged + untracked (broadest, feature branch only)
+	ModeStaged                    // staged + unstaged + untracked
+	ModeStagedOnly                // staged only (no unstaged or untracked)
+	ModeUnstaged                  // unstaged + untracked only (narrowest)
 )
 
 type focusPanel int
@@ -768,9 +769,9 @@ func (m Model) sliderModeAt(x int) DiffMode {
 // Order matches display: Branch · Staged · Unstaged (broadest → narrowest).
 func (m Model) availableModes() []DiffMode {
 	if m.onDefaultBranch {
-		return []DiffMode{ModeStaged, ModeUnstaged}
+		return []DiffMode{ModeStaged, ModeStagedOnly, ModeUnstaged}
 	}
-	return []DiffMode{ModeBranch, ModeStaged, ModeUnstaged}
+	return []DiffMode{ModeBranch, ModeStaged, ModeStagedOnly, ModeUnstaged}
 }
 
 // cycleMode advances the mode by direction (+1 or -1), wrapping around.
@@ -804,6 +805,8 @@ func (m *Model) loadDiff() tea.Cmd {
 			diff, err = git.BranchDiffOptions(ctx, hideWS)
 		case ModeStaged:
 			diff, err = git.WorkingTreeDiffOptions(ctx, hideWS)
+		case ModeStagedOnly:
+			diff, err = git.StagedOnlyDiffOptions(ctx, hideWS)
 		case ModeUnstaged:
 			diff, err = git.UnstagedOnlyDiffOptions(ctx, hideWS)
 		}
@@ -841,12 +844,13 @@ func (m Model) renderModeSlider() string {
 
 	// Cumulative: broadest mode (ModeBranch) lights all,
 	// narrower modes drop components from the left.
+	// ModeStagedOnly lights only Staged; ModeUnstaged lights only Unstaged.
 	if !m.onDefaultBranch {
 		labels = append(labels, label{"Branch", m.mode == ModeBranch})
 	}
 	labels = append(labels,
-		label{"Staged", m.mode == ModeBranch || m.mode == ModeStaged},
-		label{"Unstaged", true},
+		label{"Staged", m.mode == ModeBranch || m.mode == ModeStaged || m.mode == ModeStagedOnly},
+		label{"Unstaged", m.mode == ModeBranch || m.mode == ModeStaged || m.mode == ModeUnstaged},
 	)
 
 	var result string

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -315,6 +315,8 @@ func TestCycleMode_ForwardOnFeatureBranch(t *testing.T) {
 	m.cycleMode(+1)
 	assert.Equal(t, ModeStaged, m.mode)
 	m.cycleMode(+1)
+	assert.Equal(t, ModeStagedOnly, m.mode)
+	m.cycleMode(+1)
 	assert.Equal(t, ModeUnstaged, m.mode)
 	m.cycleMode(+1)
 	assert.Equal(t, ModeBranch, m.mode) // wraps
@@ -325,6 +327,8 @@ func TestCycleMode_BackwardOnFeatureBranch(t *testing.T) {
 	m.cycleMode(-1)
 	assert.Equal(t, ModeUnstaged, m.mode) // wraps backward
 	m.cycleMode(-1)
+	assert.Equal(t, ModeStagedOnly, m.mode)
+	m.cycleMode(-1)
 	assert.Equal(t, ModeStaged, m.mode)
 }
 
@@ -334,6 +338,8 @@ func TestCycleMode_SkipsBranchOnDefaultBranch(t *testing.T) {
 	m = updated.(Model)
 
 	assert.Equal(t, ModeStaged, m.mode) // starts on broadest available
+	m.cycleMode(+1)
+	assert.Equal(t, ModeStagedOnly, m.mode)
 	m.cycleMode(+1)
 	assert.Equal(t, ModeUnstaged, m.mode)
 	m.cycleMode(+1)
@@ -367,7 +373,7 @@ func TestDiffRefresh_UpdatesOnDefaultBranch(t *testing.T) {
 
 	require.True(t, m.onDefaultBranch)
 	require.Equal(t, ModeStaged, m.mode)
-	require.Equal(t, []DiffMode{ModeStaged, ModeUnstaged}, m.availableModes())
+	require.Equal(t, []DiffMode{ModeStaged, ModeStagedOnly, ModeUnstaged}, m.availableModes())
 
 	// Simulate a diff refresh that reports we're no longer on the default branch
 	// (e.g., user ran `git checkout -b feature` while the app was running)
@@ -378,7 +384,7 @@ func TestDiffRefresh_UpdatesOnDefaultBranch(t *testing.T) {
 	m = updated.(Model)
 
 	assert.False(t, m.onDefaultBranch)
-	assert.Equal(t, []DiffMode{ModeBranch, ModeStaged, ModeUnstaged}, m.availableModes())
+	assert.Equal(t, []DiffMode{ModeBranch, ModeStaged, ModeStagedOnly, ModeUnstaged}, m.availableModes())
 }
 
 func TestDiffRefresh_SwitchesToFeatureBranch_KeepsCurrentMode(t *testing.T) {
@@ -457,6 +463,15 @@ func TestModeSlider_StagedMode_MixedDelimiters(t *testing.T) {
 	slider := m.renderModeSlider()
 	// Branch inactive, Staged+Unstaged active — + between Staged and Unstaged, space before Staged
 	assert.Contains(t, slider, "+")
+}
+
+func TestModeSlider_StagedOnlyMode_ShowsStagedActive(t *testing.T) {
+	m := makeModel("a.go")
+	m.mode = ModeStagedOnly
+	slider := m.renderModeSlider()
+	// Only Staged label should be active
+	assert.Contains(t, slider, "Staged")
+	assert.Contains(t, slider, "Unstaged")
 }
 
 func TestModeSlider_UnstagedMode_SpaceDelimiters(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add ModeStagedOnly to the Tab cycle: Branch > Staged+Unstaged > Staged-only > Unstaged
- Uses existing StagedOnlyDiff() function
- Mode slider shows Staged highlighted without Unstaged when in staged-only mode

Closes #56

## Test plan
- [x] Unit tests for mode cycling with new mode
- [x] Slider rendering test
- [ ] Manual: stage some changes, Tab to Staged-only mode, verify only staged changes visible

Generated with [Claude Code](https://claude.com/claude-code)