### PR TITLE
Add automated releases with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,37 @@
+version: 2
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README.md
+      - LICENSE
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+brews:
+  - repository:
+      owner: justincampbell
+      name: homebrew-tap
+    homepage: https://github.com/justincampbell/revise
+    description: A terminal UI for reviewing local git changes and sending feedback to Claude Code
+    license: MIT


### PR DESCRIPTION
## Summary
- Add .goreleaser.yaml for cross-platform builds (linux/darwin/windows, amd64/arm64)
- Add GitHub Actions workflow triggered on v* tag pushes
- Publishes Homebrew formula to justincampbell/homebrew-tap

Closes #5
Closes #6

## Setup needed
- Add HOMEBREW_TAP_GITHUB_TOKEN secret (PAT with write access to homebrew-tap repo)

## Test plan
- [ ] Review .goreleaser.yaml config
- [ ] Test with `goreleaser check`
- [ ] Create a tag and verify release workflow runs

Generated with [Claude Code](https://claude.com/claude-code)