### PR TITLE
Update comment display styles

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -98,10 +98,11 @@ func (m *diffViewModel) buildLines() {
 			add(renderDiffLine(line), ref)
 
 			// If this code line has a saved comment, add a display line below it.
+			// Store raw text — rendering with gutter + full-width happens in render().
 			key := ref.commentKey(m.file.Path)
 			if text, ok := m.comments[key]; ok {
 				displayRef := &lineRef{isCommentDisplay: true}
-				add(commentDisplayStyle.Render("  ╰ "+text), displayRef)
+				add(text, displayRef)
 			}
 		}
 		add("", nil)
@@ -419,6 +420,27 @@ func hunkContext(header string) string {
 	return strings.TrimSpace(parts[2])
 }
 
+// renderCommentDisplayLine renders a comment annotation line with a gutter
+// indicator and full-width highlighted background.
+func (m diffViewModel) renderCommentDisplayLine(text string, maxWidth int) string {
+	gutter := commentGutterStyle.Render("    │ ")
+	gutterWidth := ansi.StringWidth(gutter)
+	contentWidth := maxWidth - gutterWidth
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	display := text
+	if ansi.StringWidth(display) > contentWidth {
+		display = ansi.Truncate(display, contentWidth, "")
+	}
+	// Pad to fill the remaining width with the background color.
+	pad := contentWidth - ansi.StringWidth(display)
+	if pad > 0 {
+		display = display + strings.Repeat(" ", pad)
+	}
+	return " " + gutter + commentDisplayStyle.Render(display)
+}
+
 // linePrefix returns the 1-character cursor indicator for a display line.
 // The cursor is only shown when the diff pane is focused.
 func (m diffViewModel) linePrefix(absIdx int, focused bool) string {
@@ -469,6 +491,9 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 
 	renderLine := func(absIdx int) string {
 		line := m.lines[absIdx]
+		if m.isCommentDisplayLine(absIdx) {
+			return m.renderCommentDisplayLine(line, maxWidth)
+		}
 		if ansi.StringWidth(line) > maxWidth {
 			line = ansi.Truncate(line, maxWidth, "")
 		}

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -562,6 +562,68 @@ func TestCurrentHunkIndex_NoFile(t *testing.T) {
 	assert.Equal(t, -1, m.currentHunkIndex())
 }
 
+func TestBuildLines_CommentDisplayLineHasRawText(t *testing.T) {
+	m := newDiffViewModel()
+	m.file = &git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hello", NewNum: 1}},
+		}},
+	}
+	m.comments[commentKey{file: "foo.go", lineNum: 1}] = "fix this"
+	m.buildLines()
+
+	// Find the comment display line
+	var found bool
+	for i, ref := range m.lineRefs {
+		if ref != nil && ref.isCommentDisplay {
+			found = true
+			// The raw text should be stored (not pre-rendered with styles)
+			assert.Equal(t, "fix this", m.lines[i])
+			break
+		}
+	}
+	assert.True(t, found, "expected a comment display line")
+}
+
+func TestRenderCommentDisplayLine_HasGutterIndicator(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 50
+	m.height = 10
+	m.file = &git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hello", NewNum: 1}},
+		}},
+	}
+	m.comments[commentKey{file: "foo.go", lineNum: 1}] = "fix this"
+	m.buildLines()
+	rendered := m.render(true, 3, false)
+	// The rendered output should contain the comment text and the gutter indicator
+	assert.Contains(t, rendered, "fix this")
+	assert.Contains(t, rendered, "│")
+}
+
+func TestRenderCommentDisplayLine_FullWidth(t *testing.T) {
+	m := newDiffViewModel()
+	rendered := m.renderCommentDisplayLine("short", 40)
+	// Should contain the gutter indicator │
+	assert.Contains(t, rendered, "│")
+	// Should contain the comment text
+	assert.Contains(t, rendered, "short")
+}
+
+func TestRenderCommentDisplayLine_TruncatesLongText(t *testing.T) {
+	m := newDiffViewModel()
+	longText := strings.Repeat("x", 100)
+	rendered := m.renderCommentDisplayLine(longText, 30)
+	// Should not exceed the maxWidth (rendered line prefix " " + gutter + content)
+	assert.Contains(t, rendered, "│")
+	assert.Contains(t, rendered, "xxx")
+}
+
 func TestPrevHunk_FromMiddleOfHunk_GoesToStartOfCurrentHunk(t *testing.T) {
 	m := makeDiffViewModelWithHunks()
 	m.nextHunk()            // go to hunk 1

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -63,8 +63,14 @@ var (
 	// Comment count badge in file list
 	commentCountStyle = lipgloss.NewStyle().Foreground(colorYellow)
 
+	// Colors - comment background
+	colorCommentBg = lipgloss.Color("#2d2400")
+
 	// Inline comment display (persisted annotation below a code line)
-	commentDisplayStyle = lipgloss.NewStyle().Foreground(colorYellow).Italic(true)
+	commentDisplayStyle = lipgloss.NewStyle().Foreground(colorYellow).Italic(true).Background(colorCommentBg)
+
+	// Comment gutter indicator
+	commentGutterStyle = lipgloss.NewStyle().Foreground(colorYellow).Bold(true)
 
 	// Inline comment input box
 	commentInputStyle = lipgloss.NewStyle().
@@ -120,6 +126,7 @@ func init() {
 		cursorStyle = lipgloss.NewStyle().Bold(true)
 		commentCountStyle = lipgloss.NewStyle()
 		commentDisplayStyle = lipgloss.NewStyle()
+		commentGutterStyle = lipgloss.NewStyle().Bold(true)
 		commentInputStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
 		modeActiveStyle = lipgloss.NewStyle().Bold(true)
 		modeInactiveStyle = lipgloss.NewStyle()


### PR DESCRIPTION
## Summary
- Comments now render full-width with dark yellow background
- Added gutter indicator (│) aligned with code line gutters
- Long comments truncated to panel width

Closes #12

## Test plan
- [x] make test passes
- [ ] Manual: add a comment, verify full-width highlight and gutter indicator

Generated with [Claude Code](https://claude.com/claude-code)