### PR TITLE
Persist comments to temp file across restarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,9 @@ internal/
     diff_test.go               # mergeFileDiffs unit tests
     diff_integration_test.go   # GetDiff/StagedDiff/etc integration tests (real git repos)
     testhelper_test.go         # TestRepo helper for integration tests
+  comments/
+    store.go                   # JSON persistence for comments (Save/Load/StorePath)
+    store_test.go              # persistence unit tests
   ui/
     model.go                   # root Bubbletea model, layout, input routing
     filelist.go                # left panel: file list

--- a/internal/comments/store.go
+++ b/internal/comments/store.go
@@ -1,0 +1,55 @@
+// Package comments provides persistence for review comments.
+// Comments are stored as JSON in a temp directory, keyed by
+// a hash of the repository root and branch name.
+package comments
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// StorePath returns the file path for storing comments for the given repo and branch.
+// The path is deterministic: /tmp/revise/<hash>.json where hash is derived from repo:branch.
+func StorePath(repoRoot, branch string) string {
+	h := sha256.Sum256([]byte(repoRoot + ":" + branch))
+	hex := fmt.Sprintf("%x", h[:8]) // 16 hex chars
+	return filepath.Join(os.TempDir(), "revise", hex+".json")
+}
+
+// Save writes the comments map to the given path as JSON.
+// It creates parent directories if needed.
+func Save(path string, entries map[string]string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// Load reads the comments map from the given path.
+// Returns an empty map (not an error) if the file does not exist.
+func Load(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return make(map[string]string), nil
+		}
+		return nil, err
+	}
+	var entries map[string]string
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, err
+	}
+	if entries == nil {
+		entries = make(map[string]string)
+	}
+	return entries, nil
+}

--- a/internal/comments/store_test.go
+++ b/internal/comments/store_test.go
@@ -1,0 +1,101 @@
+package comments
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorePath_DeterministicForSameInput(t *testing.T) {
+	p1 := StorePath("/repo", "feature")
+	p2 := StorePath("/repo", "feature")
+	assert.Equal(t, p1, p2)
+}
+
+func TestStorePath_DiffersForDifferentRepo(t *testing.T) {
+	p1 := StorePath("/repo-a", "main")
+	p2 := StorePath("/repo-b", "main")
+	assert.NotEqual(t, p1, p2)
+}
+
+func TestStorePath_DiffersForDifferentBranch(t *testing.T) {
+	p1 := StorePath("/repo", "main")
+	p2 := StorePath("/repo", "feature")
+	assert.NotEqual(t, p1, p2)
+}
+
+func TestStorePath_IsInTmpDir(t *testing.T) {
+	p := StorePath("/repo", "main")
+	assert.Contains(t, p, "revise")
+	assert.True(t, filepath.IsAbs(p))
+}
+
+func TestStorePath_HasJSONExtension(t *testing.T) {
+	p := StorePath("/repo", "main")
+	assert.Equal(t, ".json", filepath.Ext(p))
+}
+
+func TestSaveAndLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "comments.json")
+
+	entries := map[string]string{
+		"file.go:10:false": "fix this",
+		"main.go:5:true":   "why removed?",
+	}
+
+	err := Save(path, entries)
+	require.NoError(t, err)
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, entries, loaded)
+}
+
+func TestLoad_NonExistentFile_ReturnsEmptyMap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doesnotexist.json")
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	assert.NotNil(t, loaded)
+	assert.Empty(t, loaded)
+}
+
+func TestSave_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "comments.json")
+
+	entries := map[string]string{"a:1:false": "hello"}
+	err := Save(path, entries)
+	require.NoError(t, err)
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, entries, loaded)
+}
+
+func TestSave_EmptyMap_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "comments.json")
+
+	err := Save(path, map[string]string{})
+	require.NoError(t, err)
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+}
+
+func TestLoad_CorruptedFile_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "comments.json")
+	err := os.WriteFile(path, []byte("not json"), 0644)
+	require.NoError(t, err)
+
+	_, err = Load(path)
+	assert.Error(t, err)
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -139,6 +139,15 @@ func UnstagedDiffIgnoreWhitespace(contextLines int) (string, error) {
 	return string(out), nil
 }
 
+// RepoRoot returns the absolute path to the top-level directory of the git repository.
+func RepoRoot() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse --show-toplevel: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // IsGitRepo checks if the current directory is inside a git repository.
 func IsGitRepo() bool {
 	err := exec.Command("git", "rev-parse", "--is-inside-work-tree").Run()

--- a/internal/ui/comment.go
+++ b/internal/ui/comment.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/justincampbell/revise/internal/git"
@@ -14,7 +15,51 @@ type commentKey struct {
 	isOld   bool // true for removed lines (keyed by old line number)
 }
 
+// encode returns a string representation of the key for serialization.
+func (k commentKey) encode() string {
+	return fmt.Sprintf("%s:%d:%t", k.file, k.lineNum, k.isOld)
+}
+
+// decodeCommentKey parses a string produced by commentKey.encode().
+// Returns the zero value and false if parsing fails.
+func decodeCommentKey(s string) (commentKey, bool) {
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) != 3 {
+		return commentKey{}, false
+	}
+	lineNum, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return commentKey{}, false
+	}
+	isOld, err := strconv.ParseBool(parts[2])
+	if err != nil {
+		return commentKey{}, false
+	}
+	return commentKey{file: parts[0], lineNum: lineNum, isOld: isOld}, true
+}
+
 type comments map[commentKey]string
+
+// toStringMap converts comments to a serializable string-keyed map.
+func (c comments) toStringMap() map[string]string {
+	m := make(map[string]string, len(c))
+	for k, v := range c {
+		m[k.encode()] = v
+	}
+	return m
+}
+
+// commentsFromStringMap converts a string-keyed map back to comments.
+// Invalid keys are silently skipped.
+func commentsFromStringMap(m map[string]string) comments {
+	c := make(comments, len(m))
+	for k, v := range m {
+		if key, ok := decodeCommentKey(k); ok {
+			c[key] = v
+		}
+	}
+	return c
+}
 
 func (c comments) isEmpty() bool {
 	return len(c) == 0

--- a/internal/ui/comment_test.go
+++ b/internal/ui/comment_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/justincampbell/revise/internal/git"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatExport_Empty(t *testing.T) {
@@ -74,4 +75,59 @@ func TestFormatExport_ExcludesFilesWithNoComments(t *testing.T) {
 	result := formatExport(files, c)
 	assert.Contains(t, result, "## a.go")
 	assert.NotContains(t, result, "## b.go")
+}
+
+// --- commentKey encode/decode tests ---
+
+func TestCommentKey_EncodeRoundTrip(t *testing.T) {
+	key := commentKey{file: "foo.go", lineNum: 42, isOld: false}
+	encoded := key.encode()
+	decoded, ok := decodeCommentKey(encoded)
+	require.True(t, ok)
+	assert.Equal(t, key, decoded)
+}
+
+func TestCommentKey_EncodeRoundTrip_OldLine(t *testing.T) {
+	key := commentKey{file: "bar.go", lineNum: 7, isOld: true}
+	encoded := key.encode()
+	decoded, ok := decodeCommentKey(encoded)
+	require.True(t, ok)
+	assert.Equal(t, key, decoded)
+}
+
+func TestDecodeCommentKey_InvalidFormat(t *testing.T) {
+	_, ok := decodeCommentKey("invalid")
+	assert.False(t, ok)
+}
+
+func TestDecodeCommentKey_InvalidLineNum(t *testing.T) {
+	_, ok := decodeCommentKey("file.go:abc:false")
+	assert.False(t, ok)
+}
+
+func TestDecodeCommentKey_InvalidBool(t *testing.T) {
+	_, ok := decodeCommentKey("file.go:1:notbool")
+	assert.False(t, ok)
+}
+
+func TestComments_ToStringMap_RoundTrip(t *testing.T) {
+	c := make(comments)
+	c[commentKey{file: "a.go", lineNum: 1, isOld: false}] = "fix"
+	c[commentKey{file: "b.go", lineNum: 5, isOld: true}] = "why?"
+
+	m := c.toStringMap()
+	assert.Len(t, m, 2)
+
+	restored := commentsFromStringMap(m)
+	assert.Equal(t, c, restored)
+}
+
+func TestCommentsFromStringMap_SkipsInvalidKeys(t *testing.T) {
+	m := map[string]string{
+		"valid.go:1:false": "ok",
+		"invalid":          "skip",
+	}
+	c := commentsFromStringMap(m)
+	assert.Len(t, c, 1)
+	assert.Equal(t, "ok", c[commentKey{file: "valid.go", lineNum: 1, isOld: false}])
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	commentstore "github.com/justincampbell/revise/internal/comments"
 	"github.com/justincampbell/revise/internal/git"
 )
 
@@ -65,6 +66,7 @@ type Model struct {
 	hideWhitespace  bool
 
 	comments           comments
+	storePath          string // path to JSON file for comment persistence
 	commentInputActive bool
 	commentTarget      commentKey
 	statusMsg          string
@@ -75,10 +77,25 @@ type Model struct {
 }
 
 func New(diff *git.Diff, onDefaultBranch bool) Model {
+	return NewWithStorePath(diff, onDefaultBranch, "")
+}
+
+// NewWithStorePath creates a Model with comment persistence at the given path.
+// If storePath is non-empty, comments are loaded from it on startup and saved
+// automatically on every add/edit/delete.
+func NewWithStorePath(diff *git.Diff, onDefaultBranch bool, storePath string) Model {
 	fl := newFileListModel(diff.Files)
 	dv := newDiffViewModel()
 
 	c := make(comments)
+
+	// Load persisted comments if a store path is configured.
+	if storePath != "" {
+		if loaded, err := commentstore.Load(storePath); err == nil {
+			c = commentsFromStringMap(loaded)
+		}
+	}
+
 	dv.comments = c
 	fl.comments = c
 
@@ -97,6 +114,7 @@ func New(diff *git.Diff, onDefaultBranch bool) Model {
 		diffView:        dv,
 		focus:           focusFileList,
 		comments:        c,
+		storePath:       storePath,
 		mode:            mode,
 		onDefaultBranch: onDefaultBranch,
 		contextLines:    git.DefaultContextLines,
@@ -453,6 +471,7 @@ func (m Model) updateCommentInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			delete(m.comments, m.commentTarget)
 		}
+		m.saveComments()
 		m.commentInputActive = false
 		m.diffView.commentInputActive = false
 		m.diffView.textInput.Blur()
@@ -479,6 +498,14 @@ func (m Model) updateConfirmDiscard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.pendingDiscardCmd = nil
 		return m, nil
 	}
+}
+
+// saveComments persists comments to the configured store path (if any).
+func (m *Model) saveComments() {
+	if m.storePath == "" {
+		return
+	}
+	_ = commentstore.Save(m.storePath, m.comments.toStringMap())
 }
 
 func (m *Model) startCommentInput() {
@@ -514,6 +541,7 @@ func (m *Model) deleteCommentAtCursor() {
 	}
 	key := ref.commentKey(m.diffView.file.Path)
 	delete(m.comments, key)
+	m.saveComments()
 	m.diffView.rebuildLinesPreservingCursor()
 }
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"path/filepath"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -973,4 +974,88 @@ func TestRenderStatusBar_DiffNoPaneTotals(t *testing.T) {
 	m.focus = focusDiffView
 	status := m.renderStatusBar()
 	assert.NotContains(t, status, "a.go +1/-1")
+}
+
+// --- Comment persistence tests ---
+
+// makeModelWithStore creates a model with diff lines and a temp store path.
+func makeModelWithStore(t *testing.T, filePath string, lines []git.Line) (Model, string) {
+	t.Helper()
+	storePath := filepath.Join(t.TempDir(), "comments.json")
+	hunk := git.Hunk{
+		Header: "@@ -1,1 +1,1 @@",
+		Lines:  lines,
+	}
+	files := []git.FileDiff{{
+		Path:   filePath,
+		Status: git.StatusModified,
+		Hunks:  []git.Hunk{hunk},
+	}}
+	m := NewWithStorePath(&git.Diff{Files: files}, false, storePath)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	return updated.(Model), storePath
+}
+
+func TestModelComment_PersistsOnSave(t *testing.T) {
+	lines := []git.Line{
+		{Type: git.LineAdded, Content: "hello", NewNum: 1},
+	}
+	m, storePath := makeModelWithStore(t, "foo.go", lines)
+
+	// Add a comment
+	m = focusDiffAndMoveTo(m, 0)
+	m = sendKey(m, "c")
+	m = sendKey(m, "h")
+	m = sendKey(m, "i")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	// Create a new model from the same store — should load the comment
+	m2 := NewWithStorePath(&git.Diff{Files: []git.FileDiff{{
+		Path:   "foo.go",
+		Status: git.StatusModified,
+		Hunks:  []git.Hunk{{Header: "@@ -1,1 +1,1 @@", Lines: lines}},
+	}}}, false, storePath)
+	updated2, _ := m2.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m2 = updated2.(Model)
+
+	assert.Equal(t, "hi", m2.comments[commentKey{file: "foo.go", lineNum: 1}])
+}
+
+func TestModelComment_PersistsOnDelete(t *testing.T) {
+	lines := []git.Line{
+		{Type: git.LineAdded, Content: "hello", NewNum: 1},
+	}
+	m, storePath := makeModelWithStore(t, "foo.go", lines)
+
+	// Add a comment
+	m.comments[commentKey{file: "foo.go", lineNum: 1}] = "to delete"
+	m.saveComments()
+
+	// Delete the comment
+	m = focusDiffAndMoveTo(m, 0)
+	m = sendKey(m, "d")
+
+	// Create a new model — comment should be gone
+	m2 := NewWithStorePath(&git.Diff{Files: []git.FileDiff{{
+		Path:   "foo.go",
+		Status: git.StatusModified,
+		Hunks:  []git.Hunk{{Header: "@@ -1,1 +1,1 @@", Lines: lines}},
+	}}}, false, storePath)
+	assert.Empty(t, m2.comments)
+}
+
+func TestModelComment_NoStorePathDoesNotPersist(t *testing.T) {
+	// With empty storePath, comments should still work in memory but not persist
+	m := makeModelWithDiff("foo.go", []git.Line{
+		{Type: git.LineAdded, Content: "hello", NewNum: 1},
+	})
+	m = focusDiffAndMoveTo(m, 0)
+	m = sendKey(m, "c")
+	m = sendKey(m, "h")
+	m = sendKey(m, "i")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	assert.Equal(t, "hi", m.comments[commentKey{file: "foo.go", lineNum: 1}])
+	// No panic, no error — just works in memory
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/justincampbell/revise/internal/comments"
 	"github.com/justincampbell/revise/internal/git"
 	"github.com/justincampbell/revise/internal/ui"
 )
@@ -55,7 +56,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	m := ui.New(diff, onDefaultBranch)
+	// Compute the store path for comment persistence.
+	var storePath string
+	if repoRoot, err := git.RepoRoot(); err == nil {
+		branch := git.CurrentBranchName()
+		if branch == "" {
+			branch = "HEAD"
+		}
+		storePath = comments.StorePath(repoRoot, branch)
+	}
+
+	m := ui.NewWithStorePath(diff, onDefaultBranch, storePath)
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
## Summary
- New `internal/comments/` package for JSON persistence at `/tmp/revise/<hash>.json`
- Comments auto-saved on every add/edit/delete
- Loaded on startup via `NewWithStorePath()`
- Path derived from repo root + branch name (SHA256 hash)
- Graceful fallback when no store path (tests, edge cases)

Closes #11

## Test plan
- [x] make test passes (18 new tests)
- [ ] Manual: add comments, quit, restart revise — comments should persist

Generated with [Claude Code](https://claude.com/claude-code)