### PR TITLE
Add toggleable tree view for file list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ internal/
     styles.go                  # all Lipgloss styles, NO_COLOR support
     help.go                    # help overlay
     model_test.go              # model key routing tests
-    filelist_test.go           # navigation and truncate tests
+    filelist_test.go           # navigation, truncate, and tree view tests
     diffview_test.go           # scroll logic and gutter format tests
     help_test.go               # padRight unicode tests
 ```
@@ -144,6 +144,7 @@ Bubbletea maps the Escape key to the string `"esc"` (not `"escape"`) — use `ca
 | `n` / `N` | Next / prev file |
 | `Tab` / `Shift+Tab` | Cycle diff mode |
 | `+`/`-` | More/fewer context lines |
+| `t` | Toggle tree view in file list |
 | `f` | Toggle fullscreen diff |
 | `Esc` | Back to file list (exits fullscreen if needed) |
 | `?` | Toggle help overlay |
@@ -160,6 +161,16 @@ Bubbletea maps the Escape key to the string `"esc"` (not `"escape"`) — use `ca
 | `s` / `S` | Stage hunk / file (file list: `s` stages file) |
 | `u` / `U` | Unstage hunk / file (file list: `u` unstages file) |
 | `D` | Discard hunk / file (with `y` confirmation) |
+
+### File List Tree View
+
+- Toggle with `t` key (works from either panel)
+- Groups files by directory with indentation; directories shown as `dir/` with dim style
+- Cursor navigates files only (directory headers are skipped)
+- `buildTreeRows()` creates a flat list of `treeRow` structs from files, emitting directory headers when the directory path changes
+- Tree state (`treeView` bool) is preserved across diff refreshes
+- Mouse clicks on directory headers are ignored; clicks on file rows select the file
+- Default is flat view (tree off)
 
 ### Mouse Support
 

--- a/internal/ui/filelist.go
+++ b/internal/ui/filelist.go
@@ -7,6 +7,14 @@ import (
 	"github.com/justincampbell/revise/internal/git"
 )
 
+// treeRow represents a single row in the tree view — either a directory header or a file.
+type treeRow struct {
+	name    string // display name (just the basename or dir name with trailing /)
+	depth   int    // indentation level
+	isDir   bool   // true for directory headers
+	fileIdx int    // index into files slice (-1 for dirs)
+}
+
 type fileListModel struct {
 	files    []git.FileDiff
 	cursor   int
@@ -14,6 +22,8 @@ type fileListModel struct {
 	width    int
 	offset   int // scroll offset
 	comments comments
+	treeView bool      // toggle between flat and tree view
+	treeRows []treeRow // cached tree rows, rebuilt when files change or tree toggled
 }
 
 func newFileListModel(files []git.FileDiff) fileListModel {
@@ -21,6 +31,27 @@ func newFileListModel(files []git.FileDiff) fileListModel {
 		files:    files,
 		comments: make(comments),
 	}
+}
+
+func (m *fileListModel) toggleTreeView() {
+	m.treeView = !m.treeView
+	if m.treeView {
+		m.rebuildTreeRows()
+	}
+}
+
+func (m *fileListModel) rebuildTreeRows() {
+	m.treeRows = buildTreeRows(m.files)
+}
+
+// treeRowForFile returns the tree row index for the given file index.
+func (m *fileListModel) treeRowForFile(fileIdx int) int {
+	for i, r := range m.treeRows {
+		if !r.isDir && r.fileIdx == fileIdx {
+			return i
+		}
+	}
+	return 0
 }
 
 func (m *fileListModel) moveUp() {
@@ -39,11 +70,22 @@ func (m *fileListModel) moveDown() {
 
 func (m *fileListModel) ensureVisible() {
 	viewHeight := m.viewHeight()
-	if m.cursor < m.offset {
-		m.offset = m.cursor
-	}
-	if m.cursor >= m.offset+viewHeight {
-		m.offset = m.cursor - viewHeight + 1
+	if m.treeView && len(m.treeRows) > 0 {
+		// In tree view, offset is in tree row indices
+		treeIdx := m.treeRowForFile(m.cursor)
+		if treeIdx < m.offset {
+			m.offset = treeIdx
+		}
+		if treeIdx >= m.offset+viewHeight {
+			m.offset = treeIdx - viewHeight + 1
+		}
+	} else {
+		if m.cursor < m.offset {
+			m.offset = m.cursor
+		}
+		if m.cursor >= m.offset+viewHeight {
+			m.offset = m.cursor - viewHeight + 1
+		}
 	}
 }
 
@@ -99,6 +141,19 @@ func (m fileListModel) render(focused bool, modeSlider string) string {
 
 	var b strings.Builder
 
+	if m.treeView && len(m.treeRows) > 0 {
+		m.renderTree(&b)
+	} else {
+		m.renderFlat(&b)
+	}
+
+	rendered := style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(b.String())
+
+	rendered = setBorderTitleCentered(rendered, modeSlider, focused)
+	return rendered
+}
+
+func (m fileListModel) renderFlat(b *strings.Builder) {
 	viewHeight := m.viewHeight()
 	end := m.offset + viewHeight
 	if end > len(m.files) {
@@ -127,11 +182,47 @@ func (m fileListModel) render(focused bool, modeSlider string) string {
 			b.WriteString("\n")
 		}
 	}
+}
 
-	rendered := style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(b.String())
+func (m fileListModel) renderTree(b *strings.Builder) {
+	viewHeight := m.viewHeight()
+	end := m.offset + viewHeight
+	if end > len(m.treeRows) {
+		end = len(m.treeRows)
+	}
 
-	rendered = setBorderTitleCentered(rendered, modeSlider, focused)
-	return rendered
+	for i := m.offset; i < end; i++ {
+		row := m.treeRows[i]
+		indent := strings.Repeat("  ", row.depth)
+
+		if row.isDir {
+			// Directory header
+			b.WriteString(unselectedStyle.Render("  " + indent + row.name))
+		} else {
+			f := m.files[row.fileIdx]
+			status := statusIndicator(f.Status)
+			count := m.comments.countForFile(f.Path)
+			countSuffix := ""
+			if count > 0 {
+				countSuffix = fmt.Sprintf(" (%d)", count)
+			}
+			// Available width: total width - prefix(2) - indent - status(1) - space(1) - countSuffix
+			availWidth := m.width - 4 - len(indent) - len(countSuffix)
+			name := truncate(row.name, availWidth)
+
+			if row.fileIdx == m.cursor {
+				prefix := "▸ "
+				b.WriteString(selectedStyle.Render(prefix+indent+status+" "+name) + commentCountStyle.Render(countSuffix))
+			} else {
+				prefix := "  "
+				b.WriteString(unselectedStyle.Render(prefix+indent+status+" "+name) + commentCountStyle.Render(countSuffix))
+			}
+		}
+
+		if i < end-1 {
+			b.WriteString("\n")
+		}
+	}
 }
 
 func statusIndicator(s git.FileStatus) string {
@@ -162,6 +253,60 @@ func truncate(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return "…" + s[len(s)-maxLen+1:]
+}
+
+// buildTreeRows creates a flat list of tree rows from the file list,
+// grouping files by directory with indentation.
+func buildTreeRows(files []git.FileDiff) []treeRow {
+	if len(files) == 0 {
+		return nil
+	}
+
+	type dirEntry struct {
+		name    string
+		depth   int
+		fileIdx int // -1 for directory
+	}
+
+	var rows []treeRow
+	// Track which directory path segments have been emitted at each depth
+	var currentDirs []string // current directory path segments
+
+	for fileIdx, f := range files {
+		parts := strings.Split(f.Path, "/")
+		dirParts := parts[:len(parts)-1]
+		fileName := parts[len(parts)-1]
+
+		// Find how many leading directory segments match
+		commonDepth := 0
+		for commonDepth < len(currentDirs) && commonDepth < len(dirParts) {
+			if currentDirs[commonDepth] != dirParts[commonDepth] {
+				break
+			}
+			commonDepth++
+		}
+
+		// Emit new directory rows for segments beyond the common prefix
+		for d := commonDepth; d < len(dirParts); d++ {
+			rows = append(rows, treeRow{
+				name:    dirParts[d] + "/",
+				depth:   d,
+				isDir:   true,
+				fileIdx: -1,
+			})
+		}
+		currentDirs = dirParts
+
+		// Emit the file row
+		rows = append(rows, treeRow{
+			name:    fileName,
+			depth:   len(dirParts),
+			isDir:   false,
+			fileIdx: fileIdx,
+		})
+	}
+
+	return rows
 }
 
 func renderPaneChangeSummary(added, removed int) string {

--- a/internal/ui/filelist_test.go
+++ b/internal/ui/filelist_test.go
@@ -119,6 +119,178 @@ func TestFileTotals(t *testing.T) {
 	assert.Equal(t, 1, removed)
 }
 
+// --- Tree view tests ---
+
+func makeFilesWithStatus(entries ...struct {
+	path   string
+	status git.FileStatus
+}) []git.FileDiff {
+	files := make([]git.FileDiff, len(entries))
+	for i, e := range entries {
+		files[i] = git.FileDiff{Path: e.path, Status: e.status}
+	}
+	return files
+}
+
+func TestBuildTreeRows_SingleFile(t *testing.T) {
+	files := makeFiles("main.go")
+	rows := buildTreeRows(files)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 0, rows[0].fileIdx)
+	assert.Equal(t, 0, rows[0].depth)
+	assert.Equal(t, "main.go", rows[0].name)
+	assert.False(t, rows[0].isDir)
+}
+
+func TestBuildTreeRows_NestedFiles(t *testing.T) {
+	files := makeFiles(
+		"internal/git/apply.go",
+		"internal/git/parse.go",
+		"internal/ui/model.go",
+		"main.go",
+	)
+	rows := buildTreeRows(files)
+
+	// Expected:
+	// internal/          (dir, depth 0)
+	//   git/             (dir, depth 1)
+	//     apply.go       (file, depth 2, fileIdx 0)
+	//     parse.go       (file, depth 2, fileIdx 1)
+	//   ui/              (dir, depth 1)
+	//     model.go       (file, depth 2, fileIdx 2)
+	// main.go            (file, depth 0, fileIdx 3)
+
+	require.Len(t, rows, 7)
+
+	assert.True(t, rows[0].isDir)
+	assert.Equal(t, "internal/", rows[0].name)
+	assert.Equal(t, 0, rows[0].depth)
+
+	assert.True(t, rows[1].isDir)
+	assert.Equal(t, "git/", rows[1].name)
+	assert.Equal(t, 1, rows[1].depth)
+
+	assert.False(t, rows[2].isDir)
+	assert.Equal(t, "apply.go", rows[2].name)
+	assert.Equal(t, 2, rows[2].depth)
+	assert.Equal(t, 0, rows[2].fileIdx)
+
+	assert.False(t, rows[3].isDir)
+	assert.Equal(t, "parse.go", rows[3].name)
+	assert.Equal(t, 2, rows[3].depth)
+	assert.Equal(t, 1, rows[3].fileIdx)
+
+	assert.True(t, rows[4].isDir)
+	assert.Equal(t, "ui/", rows[4].name)
+	assert.Equal(t, 1, rows[4].depth)
+
+	assert.False(t, rows[5].isDir)
+	assert.Equal(t, "model.go", rows[5].name)
+	assert.Equal(t, 2, rows[5].depth)
+	assert.Equal(t, 2, rows[5].fileIdx)
+
+	assert.False(t, rows[6].isDir)
+	assert.Equal(t, "main.go", rows[6].name)
+	assert.Equal(t, 0, rows[6].depth)
+	assert.Equal(t, 3, rows[6].fileIdx)
+}
+
+func TestBuildTreeRows_RootOnlyFiles(t *testing.T) {
+	files := makeFiles("a.go", "b.go", "c.go")
+	rows := buildTreeRows(files)
+	require.Len(t, rows, 3)
+	for i, r := range rows {
+		assert.False(t, r.isDir)
+		assert.Equal(t, i, r.fileIdx)
+		assert.Equal(t, 0, r.depth)
+	}
+}
+
+func TestBuildTreeRows_SharedPrefix(t *testing.T) {
+	files := makeFiles("cmd/serve.go", "cmd/version.go")
+	rows := buildTreeRows(files)
+	// cmd/
+	//   serve.go
+	//   version.go
+	require.Len(t, rows, 3)
+	assert.True(t, rows[0].isDir)
+	assert.Equal(t, "cmd/", rows[0].name)
+	assert.False(t, rows[1].isDir)
+	assert.Equal(t, "serve.go", rows[1].name)
+	assert.False(t, rows[2].isDir)
+	assert.Equal(t, "version.go", rows[2].name)
+}
+
+func TestFileListTreeView_Toggle(t *testing.T) {
+	m := newFileListModel(makeFiles("a.go", "b.go"))
+	assert.False(t, m.treeView)
+	m.toggleTreeView()
+	assert.True(t, m.treeView)
+	m.toggleTreeView()
+	assert.False(t, m.treeView)
+}
+
+func TestFileListTreeView_MoveDown_SkipsDirs(t *testing.T) {
+	// Files: internal/a.go, internal/b.go
+	// Tree rows: internal/ (dir), a.go, b.go
+	// cursor starts at 0 (first file = internal/a.go)
+	// moveDown should go to file index 1 (internal/b.go)
+	m := newFileListModel(makeFiles("internal/a.go", "internal/b.go"))
+	m.treeView = true
+	m.rebuildTreeRows()
+	assert.Equal(t, 0, m.cursor) // file index 0
+	m.moveDown()
+	assert.Equal(t, 1, m.cursor) // file index 1
+	m.moveDown()
+	assert.Equal(t, 1, m.cursor) // clamped
+}
+
+func TestFileListTreeView_MoveUp_SkipsDirs(t *testing.T) {
+	m := newFileListModel(makeFiles("internal/a.go", "internal/b.go"))
+	m.treeView = true
+	m.rebuildTreeRows()
+	m.cursor = 1
+	m.moveUp()
+	assert.Equal(t, 0, m.cursor)
+	m.moveUp()
+	assert.Equal(t, 0, m.cursor) // clamped
+}
+
+func TestFileListTreeView_SelectedFile(t *testing.T) {
+	m := newFileListModel(makeFiles("internal/a.go", "internal/b.go"))
+	m.treeView = true
+	m.rebuildTreeRows()
+	m.cursor = 1
+	f := m.selectedFile()
+	require.NotNil(t, f)
+	assert.Equal(t, "internal/b.go", f.Path)
+}
+
+func TestFileListTreeView_EnsureVisible(t *testing.T) {
+	files := makeFiles(
+		"internal/git/a.go",
+		"internal/git/b.go",
+		"internal/git/c.go",
+		"internal/git/d.go",
+		"internal/git/e.go",
+	)
+	m := newFileListModel(files)
+	m.treeView = true
+	m.rebuildTreeRows()
+	m.height = 3
+	// Move to last file
+	m.cursor = 4
+	m.ensureVisible()
+	// In tree view, row for file index 4 is at tree row 6 (dir + dir + 5 files)
+	// offset should scroll so that row is visible
+	assert.True(t, m.offset >= 0)
+}
+
+func TestBuildTreeRows_EmptyFiles(t *testing.T) {
+	rows := buildTreeRows(nil)
+	assert.Len(t, rows, 0)
+}
+
 func TestFileListTotals(t *testing.T) {
 	m := newFileListModel([]git.FileDiff{
 		{

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -20,6 +20,7 @@ var allBindings = []BindingGroup{
 		{"→ (l)", "Focus diff view"},
 		{"n/N", "Next/prev file"},
 		{"Tab/S-Tab", "Cycle diff mode"},
+		{"t", "Toggle tree view"},
 		{"f", "Toggle fullscreen diff"},
 		{"Esc", "Back to file list"},
 		{"?", "Toggle help"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -148,6 +148,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.focus = focusFileList
 			return m, nil
 
+		case "t":
+			m.fileList.toggleTreeView()
+			return m, nil
+
 		case "f":
 			m.fullscreen = !m.fullscreen
 			if m.fullscreen {
@@ -250,10 +254,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if !m.mouseFocusDiff(msg) {
 				// border (1) = 1 line before file entries
 				if !m.commentInputActive {
-					idx := msg.Y - 1 + m.fileList.offset
-					if idx >= 0 && idx < len(m.fileList.files) {
-						m.fileList.cursor = idx
-						m.syncSelectedFile()
+					clickRow := msg.Y - 1 + m.fileList.offset
+					if m.fileList.treeView && len(m.fileList.treeRows) > 0 {
+						if clickRow >= 0 && clickRow < len(m.fileList.treeRows) {
+							row := m.fileList.treeRows[clickRow]
+							if !row.isDir && row.fileIdx >= 0 && row.fileIdx < len(m.fileList.files) {
+								m.fileList.cursor = row.fileIdx
+								m.syncSelectedFile()
+							}
+						}
+					} else {
+						if clickRow >= 0 && clickRow < len(m.fileList.files) {
+							m.fileList.cursor = clickRow
+							m.syncSelectedFile()
+						}
 					}
 				}
 			} else {
@@ -317,8 +331,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if f := m.fileList.selectedFile(); f != nil {
 			selectedPath = f.Path
 		}
+		wasTreeView := m.fileList.treeView
 		m.fileList = newFileListModel(m.diff.Files)
 		m.fileList.comments = m.comments
+		if wasTreeView {
+			m.fileList.treeView = true
+			m.fileList.rebuildTreeRows()
+		}
 		m.updateLayout()
 		// Re-select the same file if it still exists
 		if selectedPath != "" {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -921,6 +921,35 @@ func TestModelFileList_D_BranchOnlyFile_ShowsError(t *testing.T) {
 	assert.False(t, m.confirmDiscard)
 }
 
+// --- Tree view toggle tests ---
+
+func TestModelT_TogglesTreeView(t *testing.T) {
+	m := makeModel("internal/a.go", "internal/b.go")
+	assert.False(t, m.fileList.treeView)
+	m = sendKey(m, "t")
+	assert.True(t, m.fileList.treeView)
+	m = sendKey(m, "t")
+	assert.False(t, m.fileList.treeView)
+}
+
+func TestModelT_TreeViewPreservesCursor(t *testing.T) {
+	m := makeModel("internal/a.go", "internal/b.go", "main.go")
+	m.fileList.cursor = 1 // select internal/b.go
+	m = sendKey(m, "t")   // toggle tree view
+	assert.True(t, m.fileList.treeView)
+	assert.Equal(t, 1, m.fileList.cursor) // still on file index 1
+	f := m.fileList.selectedFile()
+	require.NotNil(t, f)
+	assert.Equal(t, "internal/b.go", f.Path)
+}
+
+func TestModelT_WorksFromDiffView(t *testing.T) {
+	m := makeModel("internal/a.go")
+	m = sendKey(m, "l") // focus diff
+	m = sendKey(m, "t")
+	assert.True(t, m.fileList.treeView)
+}
+
 // --- Hide whitespace tests ---
 
 func TestModelW_TogglesHideWhitespace(t *testing.T) {


### PR DESCRIPTION
## Summary
- Press `t` to toggle between flat and tree view in the file list
- Files grouped by directory with indented rendering
- Directory headers shown but skipped during navigation
- Mouse clicks account for tree rows
- Tree state preserved across diff refreshes

Closes #3

## Test plan
- [x] make test passes (13 new tests)
- [ ] Manual: press t to toggle, verify directory grouping and navigation

Generated with [Claude Code](https://claude.com/claude-code)