### PR TITLE
Jump past last hunk with } key

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -282,6 +282,7 @@ func (m *diffViewModel) hunkStarts() []int {
 }
 
 // nextHunk moves the cursor to the first navigable line of the next hunk.
+// If already in the last hunk, jumps to the last navigable line.
 func (m *diffViewModel) nextHunk() {
 	starts := m.hunkStarts()
 	for _, idx := range starts {
@@ -293,6 +294,12 @@ func (m *diffViewModel) nextHunk() {
 			}
 			return
 		}
+	}
+	// No next hunk found — jump to last navigable line (past the last hunk).
+	m.goToLastNavigable()
+	viewH := m.viewHeight()
+	if m.cursor >= m.offset+viewH {
+		m.offset = m.cursor - viewH + 1
 	}
 }
 

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -449,15 +449,15 @@ func TestNextHunk_FromMiddleOfHunk(t *testing.T) {
 	assert.Equal(t, 11, m.lineRefs[m.cursor].newNum) // first line of hunk 1
 }
 
-func TestNextHunk_FromLastHunk_StaysAtBottom(t *testing.T) {
+func TestNextHunk_FromLastHunk_JumpsToEnd(t *testing.T) {
 	m := makeDiffViewModelWithHunks()
 	// Go to last hunk
 	m.nextHunk()
 	m.nextHunk()
 	assert.Equal(t, 22, m.lineRefs[m.cursor].newNum) // first line of hunk 2
 	m.nextHunk()
-	// Should stay on last hunk's first line (no more hunks)
-	assert.Equal(t, 22, m.lineRefs[m.cursor].newNum)
+	// Should jump to the last navigable line (past the last hunk)
+	assert.Equal(t, 23, m.lineRefs[m.cursor].newNum)
 }
 
 func TestPrevHunk_MovesToFirstLineOfPrevHunk(t *testing.T) {
@@ -473,6 +473,26 @@ func TestPrevHunk_FromFirstHunk_StaysAtTop(t *testing.T) {
 	m := makeDiffViewModelWithHunks()
 	m.prevHunk()
 	assert.Equal(t, 1, m.lineRefs[m.cursor].newNum) // still on first line
+}
+
+func TestNextHunk_FromLastHunk_JumpsPastToLastLine(t *testing.T) {
+	m := makeDiffViewModelWithHunks()
+	// Go to last hunk
+	m.nextHunk()
+	m.nextHunk()
+	assert.Equal(t, 22, m.lineRefs[m.cursor].newNum) // first line of hunk 2
+	m.nextHunk()
+	// Should jump to the last navigable line (past the last hunk)
+	assert.Equal(t, 23, m.lineRefs[m.cursor].newNum) // added3, last navigable line
+}
+
+func TestPrevHunk_FromFirstLineOfFirstHunk_JumpsToTop(t *testing.T) {
+	m := makeDiffViewModelWithHunks()
+	// Cursor is already on first navigable line (first line of first hunk)
+	assert.Equal(t, 1, m.lineRefs[m.cursor].newNum)
+	// prevHunk should be a no-op since we're already at the start of the first hunk
+	m.prevHunk()
+	assert.Equal(t, 1, m.lineRefs[m.cursor].newNum)
 }
 
 func TestCurrentHunkIndex_FirstHunk(t *testing.T) {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -607,11 +607,10 @@ func TestModelNextHunk_Key(t *testing.T) {
 		{Type: git.LineAdded, Content: "b", NewNum: 2},
 	})
 	m = sendKey(m, "l") // focus diff
-	startCursor := m.diffView.cursor
-	// } should move to next hunk (or stay if only one)
+	// } should jump to last navigable line when no next hunk
 	m = sendKey(m, "}")
-	// With single hunk, cursor stays same
-	assert.Equal(t, startCursor, m.diffView.cursor)
+	// With single hunk, cursor moves to the last navigable line
+	assert.Equal(t, 2, m.diffView.lineRefs[m.diffView.cursor].newNum)
 }
 
 func TestModelPrevHunk_Key(t *testing.T) {


### PR DESCRIPTION
## Summary
- `}` now jumps to end of diff when already at/past the last hunk, instead of stopping at the last hunk header (#78)
- Added tests for the new behavior

Closes #78

## Test plan
- [ ] Open a file with multiple hunks, press `}` repeatedly — should cycle through hunks and then land at the end of the diff
- [ ] Press `{` at the first hunk — should be a no-op (stays at top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)