### PR TITLE
Show mode slider in fullscreen diff view

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -451,7 +451,7 @@ func (m *diffViewModel) currentHunkIndex() int {
 // inputBoxHeight is the number of rows the inline comment input box occupies.
 const inputBoxHeight = 3 // border top + content + border bottom
 
-func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace bool) string {
+func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace bool, modeSlider ...string) string {
 	viewH := m.viewHeight()
 	maxWidth := m.width - 3 // panel border (2) + cursor prefix (1)
 	if maxWidth < 1 {
@@ -540,7 +540,15 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 			title = " " + m.file.OldPath + " → " + m.file.Path + " "
 		}
 	}
-	if title != "" {
+	slider := ""
+	if len(modeSlider) > 0 {
+		slider = modeSlider[0]
+	}
+	if slider != "" && title != "" {
+		rendered = setBorderTitleLeftAndCenter(rendered, title, slider, focused)
+	} else if slider != "" {
+		rendered = setBorderTitleCentered(rendered, slider, focused)
+	} else if title != "" {
 		rendered = setBorderTitle(rendered, title, focused)
 	}
 	rendered = setBorderBottomCounts(rendered, added, removed, focused)
@@ -592,6 +600,51 @@ func setBorderTitle(rendered, title string, focused bool) string {
 	}
 
 	newTop := bc.Render("╭") + titleRendered + bc.Render(strings.Repeat("─", fillWidth)) + bc.Render("╮")
+	return newTop + rest
+}
+
+// setBorderTitleLeftAndCenter builds a top border with a left-aligned title and a centered title.
+// If they would overlap, only the left title is shown.
+func setBorderTitleLeftAndCenter(rendered, leftTitle, centerTitle string, focused bool) string {
+	nl := strings.IndexByte(rendered, '\n')
+	if nl < 0 {
+		return rendered
+	}
+	topLine := rendered[:nl]
+	rest := rendered[nl:]
+
+	borderColor := colorBorder
+	if focused {
+		borderColor = colorCyan
+	}
+	bc := lipgloss.NewStyle().Foreground(borderColor)
+
+	totalWidth := ansi.StringWidth(topLine)
+	leftRendered := fileStyle.Render(leftTitle)
+	leftWidth := ansi.StringWidth(leftRendered)
+	centerWidth := ansi.StringWidth(centerTitle)
+
+	// Center position calculation
+	innerWidth := totalWidth - 2 // minus ╭ and ╮
+	centerStart := (innerWidth - centerWidth) / 2
+	centerEnd := centerStart + centerWidth
+
+	// Left title occupies positions 0..leftWidth-1 (after ╭)
+	// If left title would overlap center, fall back to left-only
+	if leftWidth >= centerStart || centerEnd > innerWidth {
+		return setBorderTitle(rendered, leftTitle, focused)
+	}
+
+	// Build: ╭ + leftTitle + fill + centerTitle + fill + ╮
+	gapBeforeCenter := centerStart - leftWidth
+	gapAfterCenter := innerWidth - centerEnd
+
+	newTop := bc.Render("╭") +
+		leftRendered +
+		bc.Render(strings.Repeat("─", gapBeforeCenter)) +
+		centerTitle +
+		bc.Render(strings.Repeat("─", gapAfterCenter)) +
+		bc.Render("╮")
 	return newTop + rest
 }
 

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -324,6 +324,41 @@ func TestDiffView_TitleInBorder(t *testing.T) {
 	assert.Contains(t, rendered, "foo.go")
 }
 
+func TestDiffView_ModeSliderInBorder(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 60
+	m.height = 10
+	m.file = &git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hello", NewNum: 1}},
+		}},
+	}
+	m.buildLines()
+	rendered := m.render(true, 3, false, "Branch+Staged+Unstaged")
+	assert.Contains(t, rendered, "Branch+Staged+Unstaged")
+	assert.Contains(t, rendered, "foo.go", "file title should still appear")
+}
+
+func TestDiffView_EmptyModeSliderOmitted(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 60
+	m.height = 10
+	m.file = &git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hello", NewNum: 1}},
+		}},
+	}
+	m.buildLines()
+	// Empty mode slider should not change the border
+	rendered := m.render(true, 3, false, "")
+	assert.Contains(t, rendered, "foo.go")
+	assert.NotContains(t, rendered, "Branch")
+}
+
 func TestDiffView_RenamedTitleInBorder(t *testing.T) {
 	m := newDiffViewModel()
 	m.width = 60

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -937,7 +937,7 @@ func (m Model) View() string {
 
 	var screen string
 	if m.fullscreen {
-		panels := m.diffView.render(true, m.contextLines, m.hideWhitespace)
+		panels := m.diffView.render(true, m.contextLines, m.hideWhitespace, m.renderModeSlider())
 		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
 	} else {
 		left := m.fileList.render(m.focus == focusFileList, m.renderModeSlider())


### PR DESCRIPTION
## Summary
- Show the mode slider (Branch+Staged+Unstaged) in the diff panel top border when in fullscreen mode (#76)
- Adds `setBorderTitleLeftAndCenter()` helper to render both file title and mode slider on the same border line
- Falls back to title-only if panel is too narrow

Closes #76

## Test plan
- [ ] Press `f` to enter fullscreen — mode slider should be visible in the top border alongside the file name
- [ ] Press `Tab`/`Shift+Tab` in fullscreen — slider should update
- [ ] Narrow the terminal — should gracefully degrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)