### PR TITLE
Highlight keyboard hints, scrollable help

### DIFF
--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -6,23 +6,50 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func renderHelp(width, height int) string {
-	var b strings.Builder
+func renderHelp(width, height, scroll int) string {
+	var lines []string
 
-	b.WriteString(fileStyle.Render("Keyboard Shortcuts"))
-	b.WriteString("\n")
+	lines = append(lines, fileStyle.Render("Keyboard Shortcuts"))
 
 	for _, group := range allBindings {
-		b.WriteString("\n")
-		b.WriteString(helpDescStyle.Render(group.Name) + "\n")
+		lines = append(lines, "")
+		lines = append(lines, helpDescStyle.Render(group.Name))
 		for _, bind := range group.Bindings {
 			key := helpKeyStyle.Render(padRight(bind.Key, 14))
 			desc := helpDescStyle.Render(bind.Desc)
-			b.WriteString("  " + key + desc + "\n")
+			lines = append(lines, "  "+key+desc)
 		}
 	}
 
-	content := b.String()
+	// Available height inside the help box (border=2 + padding=2)
+	maxLines := height - 6
+	if maxLines < 3 {
+		maxLines = 3
+	}
+
+	// Clamp scroll
+	if scroll > len(lines)-maxLines {
+		scroll = len(lines) - maxLines
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+
+	end := scroll + maxLines
+	if end > len(lines) {
+		end = len(lines)
+	}
+	visible := lines[scroll:end]
+
+	// Add scroll indicators
+	if scroll > 0 {
+		visible[0] = helpDescStyle.Render("↑ scroll up") + "  " + visible[0]
+	}
+	if end < len(lines) {
+		visible = append(visible, helpDescStyle.Render("↓ scroll down"))
+	}
+
+	content := strings.Join(visible, "\n")
 
 	return lipgloss.Place(
 		width, height,

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -80,6 +80,7 @@ type Model struct {
 	diffView   diffViewModel
 	focus      focusPanel
 	showHelp   bool
+	helpScroll int
 	fullscreen bool
 	width      int
 	height     int
@@ -190,8 +191,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if m.showHelp {
-			m.showHelp = false
-			return m, nil
+			switch msg.String() {
+			case "j", "down":
+				m.helpScroll++
+				return m, nil
+			case "k", "up":
+				if m.helpScroll > 0 {
+					m.helpScroll--
+				}
+				return m, nil
+			default:
+				m.showHelp = false
+				m.helpScroll = 0
+				return m, nil
+			}
 		}
 
 		switch msg.String() {
@@ -473,7 +486,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case updateCheckMsg:
 		if msg.err == nil && msg.info != nil && msg.info.IsNewer {
 			m.updateInfo = msg.info
-			m.statusMsg = fmt.Sprintf("Update available: %s → %s (Ctrl+U to update)", msg.info.CurrentVersion, msg.info.LatestVersion)
+			m.statusMsg = fmt.Sprintf("Update available: %s → %s (", msg.info.CurrentVersion, msg.info.LatestVersion) +
+				helpKeyStyle.Render("Ctrl+U") + statusBarStyle.Render(" to update)")
 		}
 		return m, nil
 
@@ -1092,7 +1106,9 @@ func (m Model) renderModeSlider() string {
 
 func (m Model) renderStatusBar() string {
 	if m.commentInputActive {
-		return statusBarStyle.Width(m.width).Render("Enter: save  Esc: cancel")
+		hint := helpKeyStyle.Render("Enter") + statusBarStyle.Render(": save  ") +
+			helpKeyStyle.Render("Esc") + statusBarStyle.Render(": cancel")
+		return statusBarStyle.Width(m.width).Render(hint)
 	}
 
 	if m.statusMsg != "" {
@@ -1112,9 +1128,9 @@ func (m Model) renderStatusBar() string {
 
 	count := len(m.comments)
 	if count > 0 {
-		return statusBarStyle.Width(m.width).Render(fmt.Sprintf("%d comment(s)  ?", count))
+		return statusBarStyle.Width(m.width).Render(fmt.Sprintf("%d comment(s)  ", count) + helpKeyStyle.Render("?"))
 	}
-	return statusBarStyle.Width(m.width).Render("?")
+	return statusBarStyle.Width(m.width).Render(helpKeyStyle.Render("?"))
 }
 
 func (m Model) View() string {
@@ -1123,7 +1139,7 @@ func (m Model) View() string {
 	}
 
 	if m.showHelp {
-		return renderHelp(m.width, m.height)
+		return renderHelp(m.width, m.height, m.helpScroll)
 	}
 
 	statusBar := m.renderStatusBar()


### PR DESCRIPTION
## Summary
- Highlight keyboard shortcut keys in status bar with cyan bold styling (closes #93)
  - `Enter`/`Esc` in comment input mode
  - `?` help hint
  - `Ctrl+U` in update available message
- Make help overlay scrollable with j/k when content exceeds screen height (closes #89)
  - Shows scroll indicators (↑/↓) when content is truncated
  - Any non-scroll key dismisses help

## Test plan
- [x] All existing UI tests pass
- [ ] Visual: check status bar hints have cyan highlighting
- [ ] Visual: resize terminal to ~26 rows and verify help scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)