### PR TITLE
Use GitHub changelog in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ snapshot:
   version_template: "dev-{{.ShortCommit}}"
 
 changelog:
+  use: github
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
## Summary
- Switch goreleaser changelog from `git` (default) to `github` so commit SHAs and PR numbers are properly linked on the releases page (closes #94)

## Test plan
- [ ] Next release should show linked commit SHAs and PR numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)