### PR TITLE
Fix update hint never going away

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -165,7 +165,7 @@ func (m Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{
 		tea.Tick(pollInterval, func(time.Time) tea.Msg { return pollTickMsg{} }),
 	}
-	if m.currentVersion != "" {
+	if m.currentVersion != "" && update.IsSemver(m.currentVersion) {
 		ver := m.currentVersion
 		cmds = append(cmds, func() tea.Msg {
 			info, err := update.CheckForUpdate(ver, false)
@@ -488,6 +488,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateInfo = msg.info
 			m.statusMsg = fmt.Sprintf("Update available: %s → %s (", msg.info.CurrentVersion, msg.info.LatestVersion) +
 				helpKeyStyle.Render("Ctrl+U") + statusBarStyle.Render(" to update)")
+			return m, tea.Tick(10*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
 		}
 		return m, nil
 
@@ -498,7 +499,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Tick(5*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
 		}
 		m.statusMsg = fmt.Sprintf("Updated to %s — restart revise to use the new version", msg.newVersion)
-		return m, nil
+		return m, tea.Tick(10*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
 
 	case pollResultMsg:
 		if msg.err != nil {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/justincampbell/revise/internal/git"
+	"github.com/justincampbell/revise/internal/update"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1265,6 +1266,32 @@ func TestInit_ReturnsPollTickCmd(t *testing.T) {
 	m := makeModel("a.go")
 	cmd := m.Init()
 	assert.NotNil(t, cmd, "Init should return a poll tick command")
+}
+
+func TestUpdateCheckMsg_SetsStatusAndClearsAfterTimeout(t *testing.T) {
+	m := makeModel("a.go")
+
+	updated, cmd := m.Update(updateCheckMsg{
+		info: &update.UpdateInfo{
+			CurrentVersion: "0.1.0",
+			LatestVersion:  "0.2.0",
+			IsNewer:        true,
+		},
+	})
+	m = updated.(Model)
+
+	assert.Contains(t, m.statusMsg, "Update available")
+	assert.NotNil(t, cmd, "should return a clear timer command")
+}
+
+func TestUpdateApplied_SetsStatusAndClearsAfterTimeout(t *testing.T) {
+	m := makeModel("a.go")
+
+	updated, cmd := m.Update(updateAppliedMsg{newVersion: "0.2.0"})
+	m = updated.(Model)
+
+	assert.Contains(t, m.statusMsg, "Updated to 0.2.0")
+	assert.NotNil(t, cmd, "should return a clear timer command")
 }
 
 func TestPollResult_SameFingerprint_NoReload(t *testing.T) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -52,7 +52,7 @@ func CheckForUpdate(currentVersion string, includePre bool) (*UpdateInfo, error)
 	detectedRelease = latest
 
 	// Dev builds and other non-semver versions always report as needing update.
-	newer := !isSemver(currentVersion) || latest.GreaterThan(currentVersion)
+	newer := !IsSemver(currentVersion) || latest.GreaterThan(currentVersion)
 
 	return &UpdateInfo{
 		CurrentVersion: currentVersion,
@@ -63,8 +63,8 @@ func CheckForUpdate(currentVersion string, includePre bool) (*UpdateInfo, error)
 	}, nil
 }
 
-// isSemver returns true if the version string is valid semver (with or without v prefix).
-func isSemver(v string) bool {
+// IsSemver returns true if the version string is valid semver (with or without v prefix).
+func IsSemver(v string) bool {
 	s := v
 	if !strings.HasPrefix(s, "v") {
 		s = "v" + s

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestIsSemver(t *testing.T) {
-	assert.True(t, isSemver("1.0.0"))
-	assert.True(t, isSemver("v1.0.0"))
-	assert.True(t, isSemver("0.1.0"))
-	assert.True(t, isSemver("1.2.3-beta"))
-	assert.False(t, isSemver("dev"))
-	assert.False(t, isSemver("dev-abc1234"))
-	assert.False(t, isSemver(""))
-	assert.False(t, isSemver("latest"))
+	assert.True(t, IsSemver("1.0.0"))
+	assert.True(t, IsSemver("v1.0.0"))
+	assert.True(t, IsSemver("0.1.0"))
+	assert.True(t, IsSemver("1.2.3-beta"))
+	assert.False(t, IsSemver("dev"))
+	assert.False(t, IsSemver("dev-abc1234"))
+	assert.False(t, IsSemver(""))
+	assert.False(t, IsSemver("latest"))
 }
 
 func TestCheckForUpdate_DevVersion(t *testing.T) {


### PR DESCRIPTION
## Summary
- Skip update check entirely for non-semver versions (dev builds), so the "update available" hint never appears during development
- Add 10-second auto-clear timers for both "update available" and "updated successfully" status messages

Fixes #110

## Test plan
- [x] Unit tests for update check and update applied message clearing
- [ ] Run dev build (`go install .`) and verify no update hint appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)