### PR TITLE
Strip whitespace from exported line content

### DIFF
--- a/internal/ui/comment.go
+++ b/internal/ui/comment.go
@@ -76,14 +76,15 @@ func (c comments) countForFile(path string) int {
 }
 
 // findLineContent looks up the content of a line in a file's hunks.
+// Leading whitespace is stripped to keep exported output readable.
 func findLineContent(f git.FileDiff, lineNum int, isOld bool) string {
 	for _, h := range f.Hunks {
 		for _, l := range h.Lines {
 			if isOld && l.OldNum == lineNum && (l.Type == git.LineRemoved || l.Type == git.LineContext) {
-				return l.Content
+				return strings.TrimLeft(l.Content, " \t")
 			}
 			if !isOld && l.NewNum == lineNum && (l.Type == git.LineAdded || l.Type == git.LineContext) {
-				return l.Content
+				return strings.TrimLeft(l.Content, " \t")
 			}
 		}
 	}

--- a/internal/ui/comment_test.go
+++ b/internal/ui/comment_test.go
@@ -31,6 +31,23 @@ func TestFormatExport_SingleComment(t *testing.T) {
 	assert.Contains(t, result, "10: `hello world`\n> fix this")
 }
 
+func TestFormatExport_StripsLeadingWhitespace(t *testing.T) {
+	files := []git.FileDiff{{
+		Path: "comment_test.go",
+		Hunks: []git.Hunk{{
+			Lines: []git.Line{
+				{Type: git.LineAdded, Content: "\t\tHunks: []git.Hunk{{", NewNum: 211},
+			},
+		}},
+	}}
+	c := comments{
+		{file: "comment_test.go", lineNum: 211}: "Test",
+	}
+	result := formatExport(files, c)
+	assert.Contains(t, result, "211: `Hunks: []git.Hunk{{`\n> Test")
+	assert.NotContains(t, result, "\t\tHunks")
+}
+
 func TestFormatExport_MultipleFiles_OrderedByDiff(t *testing.T) {
 	files := []git.FileDiff{
 		{Path: "a.go"},


### PR DESCRIPTION
## Summary
- Strip leading whitespace (tabs/spaces) from line content in export output for readability
- Fixes #106

## Test plan
- [x] Added `TestFormatExport_StripsLeadingWhitespace` covering indented line content
- [x] All existing export tests pass
- [x] Manual testing confirmed fix works for both added and removed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code comment formatting by removing leading whitespace from displayed code snippets. Comments with code context now appear cleaner and more readable in code reviews.

* **Tests**
  * Added test validation for whitespace stripping behavior in comment display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->