### PR TITLE
Improve help overlay UX

### DIFF
--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -5,28 +5,71 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
+
+// helpLineCount returns the total number of lines in the help content.
+func helpLineCount() int {
+	n := 0
+	for _, group := range allBindings {
+		n += 2 // blank line + group name
+		n += len(group.Bindings)
+	}
+	return n
+}
+
+// helpMaxScroll returns the maximum scroll offset for the help overlay.
+func helpMaxScroll(height int) int {
+	maxLines := helpVisibleLines(height)
+	max := helpLineCount() - maxLines
+	if max < 0 {
+		return 0
+	}
+	return max
+}
+
+// helpVisibleLines returns the number of content lines visible in the help box.
+func helpVisibleLines(height int) int {
+	borderRows := 2    // top + bottom border
+	paddingRows := 1   // top padding only (PaddingTop(1))
+	indicatorRows := 2 // top + bottom scroll indicator slots
+	chrome := borderRows + paddingRows + indicatorRows
+	maxLines := height - chrome
+	if maxLines < 3 {
+		maxLines = 3
+	}
+	return maxLines
+}
 
 func renderHelp(width, height, scroll int) string {
 	var lines []string
 
-	lines = append(lines, fileStyle.Render("Keyboard Shortcuts"))
-
+	// Compute max content width from raw text (before styling) so ANSI
+	// escape sequences don't inflate the measurement.
+	maxW := 0
+	for _, group := range allBindings {
+		if w := len([]rune(group.Name)); w > maxW {
+			maxW = w
+		}
+		for _, bind := range group.Bindings {
+			// "  " + key(14) + desc
+			w := 2 + 14 + len([]rune(bind.Desc))
+			if w > maxW {
+				maxW = w
+			}
+		}
+	}
 	for _, group := range allBindings {
 		lines = append(lines, "")
-		lines = append(lines, helpDescStyle.Render(group.Name))
+		lines = append(lines, helpGroupStyle.Render(group.Name))
 		for _, bind := range group.Bindings {
 			key := helpKeyStyle.Render(padRight(bind.Key, 14))
-			desc := helpDescStyle.Render(bind.Desc)
+			desc := helpTextStyle.Render(bind.Desc)
 			lines = append(lines, "  "+key+desc)
 		}
 	}
 
-	// Available height inside the help box (border=2 + padding=2)
-	maxLines := height - 6
-	if maxLines < 3 {
-		maxLines = 3
-	}
+	maxLines := helpVisibleLines(height)
 
 	// Clamp scroll
 	if scroll > len(lines)-maxLines {
@@ -42,21 +85,64 @@ func renderHelp(width, height, scroll int) string {
 	}
 	visible := lines[scroll:end]
 
-	// Add scroll indicators
+	// Build output with dedicated scroll indicator rows.
+	var parts []string
 	if scroll > 0 {
-		visible[0] = helpDescStyle.Render("↑ scroll up") + "  " + visible[0]
+		parts = append(parts, helpDescStyle.Render("↑ scroll up"))
+	} else {
+		parts = append(parts, "")
 	}
+	parts = append(parts, visible...)
 	if end < len(lines) {
-		visible = append(visible, helpDescStyle.Render("↓ scroll down"))
+		parts = append(parts, helpDescStyle.Render("↓ scroll down"))
+	} else {
+		parts = append(parts, "")
 	}
 
-	content := strings.Join(visible, "\n")
+	content := strings.Join(parts, "\n")
 
-	return lipgloss.Place(
-		width, height,
-		lipgloss.Center, lipgloss.Center,
-		helpStyle.Render(content),
-	)
+	// lipgloss Width/Height include padding but exclude borders.
+	paddingLR := 2 + 2          // PaddingLeft(2) + PaddingRight(2)
+	paddingTop := 1             // PaddingTop(1)
+	contentRows := maxLines + 2 // visible lines + top/bottom indicator slots
+	boxWidth := maxW + paddingLR
+	boxHeight := contentRows + paddingTop
+
+	rendered := helpStyle.Width(boxWidth).Height(boxHeight).Render(content)
+
+	// Overlay "Keyboard Shortcuts" title onto the top border.
+	rendered = setHelpBorderTitle(rendered, "Keyboard Shortcuts")
+
+	return rendered
+}
+
+// setHelpBorderTitle overlays a title onto the top border of the help box.
+func setHelpBorderTitle(rendered, title string) string {
+	nl := strings.IndexByte(rendered, '\n')
+	if nl < 0 {
+		return rendered
+	}
+	topLine := rendered[:nl]
+	rest := rendered[nl:]
+
+	bc := lipgloss.NewStyle().Foreground(colorYellow)
+	titleRendered := fileStyle.Render(title)
+	titleWidth := ansi.StringWidth(titleRendered)
+	totalWidth := ansi.StringWidth(topLine)
+
+	if titleWidth+2 > totalWidth {
+		return rendered
+	}
+
+	fillWidth := totalWidth - 2 - titleWidth // minus ╭ and ╮
+	if fillWidth < 0 {
+		fillWidth = 0
+	}
+	leftFill := fillWidth / 2
+	rightFill := fillWidth - leftFill
+
+	newTop := bc.Render("╭") + bc.Render(strings.Repeat("─", leftFill)) + titleRendered + bc.Render(strings.Repeat("─", rightFill)) + bc.Render("╮")
+	return newTop + rest
 }
 
 func pluralize(n int, singular, plural string) string {

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,17 @@ func TestPadRight_UnicodeArrow(t *testing.T) {
 	// "← (h)" is 6 runes but more bytes; should pad to 14 runes
 	got := padRight("← (h)", 14)
 	assert.Equal(t, 14, len([]rune(got)))
+}
+
+func TestRenderHelp_ScrollIndicatorsAreSeparateLines(t *testing.T) {
+	// At scroll=0, first visible content line should NOT be corrupted by an indicator
+	result := renderHelp(60, 20, 0)
+	lines := strings.Split(result, "\n")
+	for _, line := range lines {
+		// No line should contain both "↑" and "Keyboard Shortcuts"
+		assert.False(t, strings.Contains(line, "↑") && strings.Contains(line, "Keyboard"),
+			"scroll indicator should not be prepended to content line")
+	}
 }
 
 func TestPluralize(t *testing.T) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -193,7 +193,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.showHelp {
 			switch msg.String() {
 			case "j", "down":
-				m.helpScroll++
+				if m.helpScroll < helpMaxScroll(m.height) {
+					m.helpScroll++
+				}
 				return m, nil
 			case "k", "up":
 				if m.helpScroll > 0 {
@@ -341,6 +343,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateDiffView(msg)
 
 	case tea.MouseMsg:
+		if m.showHelp {
+			switch msg.Button {
+			case tea.MouseButtonWheelUp:
+				if m.helpScroll > 0 {
+					m.helpScroll--
+				}
+			case tea.MouseButtonWheelDown:
+				if m.helpScroll < helpMaxScroll(m.height) {
+					m.helpScroll++
+				}
+			}
+			return m, nil
+		}
+
 		switch msg.Button {
 		case tea.MouseButtonWheelUp:
 			if m.mouseFocusDiff(msg) {
@@ -1131,10 +1147,6 @@ func (m Model) View() string {
 		return "Loading..."
 	}
 
-	if m.showHelp {
-		return renderHelp(m.width, m.height, m.helpScroll)
-	}
-
 	statusBar := m.renderStatusBar()
 
 	var screen string
@@ -1150,6 +1162,10 @@ func (m Model) View() string {
 
 	if m.confirmDiscard || m.confirmClear {
 		screen = overlayCenter(screen, m.renderConfirmDialog(), m.width, m.height)
+	}
+
+	if m.showHelp {
+		screen = overlayCenter(screen, renderHelp(m.width, m.height, m.helpScroll), m.width, m.height)
 	}
 
 	return screen

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -176,6 +176,44 @@ func TestModelHelpDismissedByAnyKey(t *testing.T) {
 	assert.False(t, m.showHelp)
 }
 
+func TestModelHelpMouseScrollDown(t *testing.T) {
+	m := makeModel("a.go")
+	m = sendKey(m, "?")
+	require.True(t, m.showHelp)
+	updated, _ := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	m = updated.(Model)
+	assert.Equal(t, 1, m.helpScroll)
+}
+
+func TestModelHelpMouseScrollUp(t *testing.T) {
+	m := makeModel("a.go")
+	m = sendKey(m, "?")
+	m.helpScroll = 5
+	updated, _ := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	m = updated.(Model)
+	assert.Equal(t, 4, m.helpScroll)
+}
+
+func TestModelHelpMouseScrollUpAtZero(t *testing.T) {
+	m := makeModel("a.go")
+	m = sendKey(m, "?")
+	require.Equal(t, 0, m.helpScroll)
+	updated, _ := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	m = updated.(Model)
+	assert.Equal(t, 0, m.helpScroll)
+}
+
+func TestModelHelpOverlayShowsBackground(t *testing.T) {
+	m := makeModel("a.go")
+	m = sendKey(m, "?")
+	require.True(t, m.showHelp)
+	view := m.View()
+	// The help overlay should contain help content
+	assert.Contains(t, view, "Keyboard Shortcuts")
+	// The background (file list) should still be visible around the overlay
+	assert.Contains(t, view, "a.go")
+}
+
 // --- Comment tests ---
 
 func TestModelComment_CursorStartsOnFirstCodeLine(t *testing.T) {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -93,12 +93,14 @@ var (
 	statusBarStyle = lipgloss.NewStyle().Foreground(colorDim)
 
 	// Help styles
-	helpKeyStyle  = lipgloss.NewStyle().Bold(true).Foreground(colorCyan)
-	helpDescStyle = lipgloss.NewStyle().Foreground(colorDim)
-	helpStyle     = lipgloss.NewStyle().
+	helpKeyStyle   = lipgloss.NewStyle().Bold(true).Foreground(colorCyan)
+	helpTextStyle  = lipgloss.NewStyle().Foreground(colorWhite)
+	helpGroupStyle = lipgloss.NewStyle().Bold(true).Foreground(colorWhite)
+	helpDescStyle  = lipgloss.NewStyle().Foreground(colorDim)
+	helpStyle      = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorCyan).
-			Padding(1, 2)
+			BorderForeground(colorYellow).
+			Padding(1, 2, 0)
 
 	// Confirm dialog styles
 	confirmStyle = lipgloss.NewStyle().
@@ -143,8 +145,10 @@ func init() {
 		modeInactiveStyle = lipgloss.NewStyle()
 		statusBarStyle = lipgloss.NewStyle()
 		helpKeyStyle = lipgloss.NewStyle().Bold(true)
+		helpTextStyle = lipgloss.NewStyle()
+		helpGroupStyle = lipgloss.NewStyle().Bold(true)
 		helpDescStyle = lipgloss.NewStyle()
-		helpStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2)
+		helpStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2, 0)
 		confirmStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2)
 		confirmKeyStyle = lipgloss.NewStyle().Bold(true)
 	}


### PR DESCRIPTION
## Summary
- Render help as overlay on top of existing UI instead of replacing it
- Add mouse scroll support in the help overlay
- Fix scroll indicators as dedicated rows (no longer overwrite content)
- Clamp scroll bounds to prevent over-scrolling
- Use fixed box dimensions (explicit Width/Height) to prevent resize while scrolling
- Move Keyboard Shortcuts title into centered border header
- Use yellow border and lighter text colors to distinguish from panel borders

Fixes #116

## Test plan
- [x] TestModelHelpMouseScrollDown/Up/UpAtZero - mouse scroll routing
- [x] TestModelHelpOverlayShowsBackground - overlay preserves background UI
- [x] TestRenderHelp_ScrollIndicatorsAreSeparateLines - indicators don't corrupt content
- [x] Manual testing: scroll up/down with mouse and keyboard, verify stable box size

Generated with [Claude Code](https://claude.com/claude-code)