### PR TITLE
Add file review mode and comment output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `--theme` flag with four color palettes: `dark` (default), `light`, `dark-daltonized`, `light-daltonized`
+- File review mode: `revise <file>` opens any file for review with comments (#55, #119)
+- Output comments to stdout on exit for Claude Code integration (#118)
 - Auto-refresh diff every 2 seconds when files change (#87)
 - Include line contents in comment export (#85)
 - File-level comments with `c`/`d` on file list (#73)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,15 @@ Four modes: ModeBranch (broadest), ModeStaged, ModeStagedOnly, ModeUnstaged (nar
 - Help overlay uses yellow border to distinguish from panels
 - Lipgloss `Width(n)`/`Height(n)` include padding but exclude borders — when setting explicit dimensions, add padding to the content size
 
+### File Review Mode
+
+`revise <file>` opens any file in a read-only review mode with full comment support. All lines are shown as context (no diff coloring). Starts fullscreen with diff view focused. Git-specific keys (stage/unstage/discard, mode cycling, context lines, whitespace toggle) are disabled — guarded by a single `fileReviewMode` check per key group in the Update handlers. The help overlay filters bindings via `FileReviewBindingGroups()` which uses the `GitOnly` flag on `Binding`.
+
+Comments are output to stdout on exit (both in file review and git diff modes), enabling integration with Claude Code: Claude launches `revise`, user reviews and comments, comments print on close.
+
 ### Keyboard Bindings
 
-All bindings are defined in `internal/ui/keys.go` (`allBindings`) and used to generate both the in-app help overlay (`?`) and the `--help` CLI output. This is the single source of truth — do not define bindings elsewhere.
+All bindings are defined in `internal/ui/keys.go` (`allBindings`) and used to generate both the in-app help overlay (`?`) and the `--help` CLI output. This is the single source of truth — do not define bindings elsewhere. Each `Binding` has a `GitOnly` flag — when true, the binding is hidden in file review mode help and disabled in input handling.
 
 Bubbletea maps the Escape key to the string `"esc"` (not `"escape"`) — use `case "esc":` in switch statements.
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,24 @@ Cycle through modes with `Tab` / `Shift+Tab`:
 | **Staged** | Staged + unstaged + untracked |
 | **Unstaged** | Unstaged + untracked only (narrowest) |
 
+### File Review
+
+Review any file with comments:
+
+```sh
+revise <file>
+revise --output comments.md <file>
+```
+
+Opens the file in a read-only review mode — all lines shown as context, git-specific keys disabled. Add comments, then quit — comments are printed to stdout on exit. Use `--output <file>` to write comments to a file instead.
+
+Comments are also output on exit in normal git diff mode.
+
 ### Subcommands
 
 | Command | Description |
 |---------|-------------|
+| `revise <file>` | Review a file with comments |
 | `revise styles` | Show file status color matrix for all staging states |
 | `revise update [--pre]` | Update to the latest version |
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -42,6 +42,7 @@ type diffViewModel struct {
 	commentInputActive bool
 	fileCommentInput   bool // true when editing a file-level comment (appears before first hunk)
 	textInput          textinput.Model
+	fileReviewMode     bool // true when reviewing a file (suppresses git chrome in render)
 }
 
 func newDiffViewModel() diffViewModel {
@@ -404,9 +405,17 @@ func renderHunkHeader(h git.Hunk) string {
 		label = "unstaged"
 	}
 
+	// No source and no header context — nothing to show (e.g. file review mode).
+	if label == "" && header == "" {
+		return ""
+	}
+
 	tag := hunkSourceTagStyle.Render("[" + label + "]")
 	if header == "" {
 		return tag
+	}
+	if label == "" {
+		return style.Render(header)
 	}
 	return tag + " " + style.Render(header)
 }
@@ -562,6 +571,18 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 		style = focusedBorder
 	}
 	rendered := style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(content)
+
+	if m.fileReviewMode {
+		// File review mode: centered filename in top border, clean bottom border.
+		slider := ""
+		if len(modeSlider) > 0 {
+			slider = modeSlider[0]
+		}
+		if slider != "" {
+			rendered = setBorderTitleCentered(rendered, fileStyle.Render(" "+slider+" "), focused)
+		}
+		return rendered
+	}
 
 	title := ""
 	if m.file != nil {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -41,13 +41,18 @@ func helpVisibleLines(height int) int {
 	return maxLines
 }
 
-func renderHelp(width, height, scroll int) string {
+func renderHelp(width, height, scroll int, groups ...[]BindingGroup) string {
+	bindings := allBindings
+	if len(groups) > 0 && groups[0] != nil {
+		bindings = groups[0]
+	}
+
 	var lines []string
 
 	// Compute max content width from raw text (before styling) so ANSI
 	// escape sequences don't inflate the measurement.
 	maxW := 0
-	for _, group := range allBindings {
+	for _, group := range bindings {
 		if w := len([]rune(group.Name)); w > maxW {
 			maxW = w
 		}
@@ -59,7 +64,7 @@ func renderHelp(width, height, scroll int) string {
 			}
 		}
 	}
-	for _, group := range allBindings {
+	for _, group := range bindings {
 		lines = append(lines, "")
 		lines = append(lines, helpGroupStyle.Render(group.Name))
 		for _, bind := range group.Bindings {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -2,8 +2,9 @@ package ui
 
 // Binding describes a keyboard shortcut for display in help.
 type Binding struct {
-	Key  string
-	Desc string
+	Key     string
+	Desc    string
+	GitOnly bool // true for bindings that only apply in git diff mode
 }
 
 // BindingGroup is a named group of keyboard shortcuts.
@@ -16,50 +17,67 @@ type BindingGroup struct {
 // The help overlay and --help output are generated from this list.
 var allBindings = []BindingGroup{
 	{"General", []Binding{
-		{"← (h)", "Focus file list"},
-		{"→ (l)", "Focus diff view"},
-		{"n/N", "Next/prev file"},
-		{"Tab/S-Tab", "Cycle diff mode"},
-		{"f", "Toggle fullscreen diff"},
-		{"Esc", "Back to file list"},
-		{"?", "Toggle help"},
-		{"q", "Quit"},
+		{Key: "← (h)", Desc: "Focus file list", GitOnly: true},
+		{Key: "→ (l)", Desc: "Focus diff view", GitOnly: true},
+		{Key: "n/N", Desc: "Next/prev file", GitOnly: true},
+		{Key: "Tab/S-Tab", Desc: "Cycle diff mode", GitOnly: true},
+		{Key: "f", Desc: "Toggle fullscreen diff", GitOnly: true},
+		{Key: "Esc", Desc: "Back to file list", GitOnly: true},
+		{Key: "?", Desc: "Toggle help"},
+		{Key: "q", Desc: "Quit"},
 	}},
 	{"File List", []Binding{
-		{"j/k, ↑/↓", "Navigate files"},
-		{"Enter", "Select file and focus diff"},
-		{"c", "Add/edit file comment"},
-		{"d", "Delete file comment"},
-		{"s", "Stage file"},
-		{"u", "Unstage file"},
-		{"D", "Discard file"},
+		{Key: "j/k, ↑/↓", Desc: "Navigate files", GitOnly: true},
+		{Key: "Enter", Desc: "Select file and focus diff", GitOnly: true},
+		{Key: "c", Desc: "Add/edit file comment", GitOnly: true},
+		{Key: "d", Desc: "Delete file comment", GitOnly: true},
+		{Key: "s", Desc: "Stage file", GitOnly: true},
+		{Key: "u", Desc: "Unstage file", GitOnly: true},
+		{Key: "D", Desc: "Discard file", GitOnly: true},
 	}},
 	{"Diff View", []Binding{
-		{"j/k, ↑/↓", "Move cursor"},
-		{"}/{ (]/[)", "Next/prev hunk"},
-		{"+/-", "More/fewer context lines"},
-		{"w", "Toggle hide whitespace"},
-		{"g/G", "Top/bottom"},
-		{"Fn+↓/↑", "Page down/up"},
-		{"Enter/c", "Add/edit comment on line"},
-		{"d", "Delete comment on line"},
-		{"s/S", "Stage hunk/file"},
-		{"u/U", "Unstage hunk/file"},
-		{"D", "Discard hunk"},
+		{Key: "j/k, ↑/↓", Desc: "Move cursor"},
+		{Key: "}/{ (]/[)", Desc: "Next/prev hunk"},
+		{Key: "+/-", Desc: "More/fewer context lines", GitOnly: true},
+		{Key: "w", Desc: "Toggle hide whitespace", GitOnly: true},
+		{Key: "g/G", Desc: "Top/bottom"},
+		{Key: "Fn+↓/↑", Desc: "Page down/up"},
+		{Key: "Enter/c", Desc: "Add/edit comment on line"},
+		{Key: "d", Desc: "Delete comment on line"},
+		{Key: "s/S", Desc: "Stage hunk/file", GitOnly: true},
+		{Key: "u/U", Desc: "Unstage hunk/file", GitOnly: true},
+		{Key: "D", Desc: "Discard hunk", GitOnly: true},
 	}},
 	{"Global", []Binding{
-		{"e", "Export comments to clipboard"},
-		{"C", "Clear all comments"},
-		{"Ctrl+U", "Apply available update"},
-		{"!", "Report issue on GitHub"},
+		{Key: "e", Desc: "Export comments to clipboard"},
+		{Key: "C", Desc: "Clear all comments"},
+		{Key: "Ctrl+U", Desc: "Apply available update", GitOnly: true},
+		{Key: "!", Desc: "Report issue on GitHub"},
 	}},
 	{"Comment Input", []Binding{
-		{"Enter", "Save comment"},
-		{"Esc", "Cancel"},
+		{Key: "Enter", Desc: "Save comment"},
+		{Key: "Esc", Desc: "Cancel"},
 	}},
 }
 
 // BindingGroups returns all keyboard shortcut groups.
 func BindingGroups() []BindingGroup {
 	return allBindings
+}
+
+// FileReviewBindingGroups returns binding groups with git-only bindings filtered out.
+func FileReviewBindingGroups() []BindingGroup {
+	var groups []BindingGroup
+	for _, g := range allBindings {
+		var bindings []Binding
+		for _, b := range g.Bindings {
+			if !b.GitOnly {
+				bindings = append(bindings, b)
+			}
+		}
+		if len(bindings) > 0 {
+			groups = append(groups, BindingGroup{Name: g.Name, Bindings: bindings})
+		}
+	}
+	return groups
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -110,6 +110,37 @@ type Model struct {
 	currentVersion string              // version string from build
 	updateInfo     *update.UpdateInfo  // populated after update check
 	updating       bool                // true while downloading update
+
+	fileReviewMode bool   // true when reviewing a file (not a git diff)
+	fileReviewPath string // filename shown in status bar
+}
+
+// NewFileReview creates a Model for reviewing a file (not a git diff).
+// It starts in fullscreen with focus on the diff view.
+func NewFileReview(diff *git.Diff, filePath string) Model {
+	fl := newFileListModel(diff.Files)
+	dv := newDiffViewModel()
+
+	c := make(comments)
+	dv.comments = c
+	dv.fileReviewMode = true
+	fl.comments = c
+
+	if len(diff.Files) > 0 {
+		dv.setFile(&diff.Files[0])
+	}
+
+	return Model{
+		diff:           diff,
+		fileList:       fl,
+		diffView:       dv,
+		focus:          focusDiffView,
+		fullscreen:     true,
+		comments:       c,
+		mode:           ModeStaged,
+		fileReviewMode: true,
+		fileReviewPath: filePath,
+	}
 }
 
 func New(diff *git.Diff, onDefaultBranch bool) Model {
@@ -165,6 +196,9 @@ func NewWithStorePath(diff *git.Diff, onDefaultBranch bool, storePath string, ve
 }
 
 func (m Model) Init() tea.Cmd {
+	if m.fileReviewMode {
+		return nil
+	}
 	cmds := []tea.Cmd{
 		tea.Tick(pollInterval, func(time.Time) tea.Msg { return pollTickMsg{} }),
 	}
@@ -221,6 +255,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "right", "l":
+			if m.fileReviewMode {
+				return m, nil
+			}
 			if m.focus == focusDiffView {
 				m.fullscreen = !m.fullscreen
 				m.updateLayout()
@@ -229,36 +266,57 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
-		case "left", "h":
-			if m.fullscreen {
-				m.fullscreen = false
+		case "left", "h", "f", "esc":
+			if m.fileReviewMode {
+				return m, nil
+			}
+			switch msg.String() {
+			case "left", "h":
+				if m.fullscreen {
+					m.fullscreen = false
+					m.updateLayout()
+				}
+				m.focus = focusFileList
+			case "f":
+				m.fullscreen = !m.fullscreen
+				if m.fullscreen {
+					m.focus = focusDiffView
+				}
 				m.updateLayout()
+			case "esc":
+				if m.fullscreen {
+					m.fullscreen = false
+					m.updateLayout()
+				}
+				m.focus = focusFileList
 			}
-			m.focus = focusFileList
 			return m, nil
 
-		case "f":
-			m.fullscreen = !m.fullscreen
-			if m.fullscreen {
-				m.focus = focusDiffView
+		// Git-only keys — no-op in file review mode
+		case "tab", "shift+tab", "w", "+", "=", "-", "_":
+			if m.fileReviewMode {
+				return m, nil
 			}
-			m.updateLayout()
-			return m, nil
-
-		case "esc":
-			if m.fullscreen {
-				m.fullscreen = false
-				m.updateLayout()
+			switch msg.String() {
+			case "tab":
+				m.cycleMode(+1)
+				return m, m.loadDiff()
+			case "shift+tab":
+				m.cycleMode(-1)
+				return m, m.loadDiff()
+			case "w":
+				m.hideWhitespace = !m.hideWhitespace
+				return m, m.loadDiff()
+			case "+", "=":
+				m.contextLines++
+				return m, m.loadDiff()
+			case "-", "_":
+				if m.contextLines > 0 {
+					m.contextLines--
+					return m, m.loadDiff()
+				}
+				return m, nil
 			}
-			m.focus = focusFileList
-			return m, nil
-
-		case "tab":
-			m.cycleMode(+1)
-			return m, m.loadDiff()
-		case "shift+tab":
-			m.cycleMode(-1)
-			return m, m.loadDiff()
 
 		// File list navigation (always works)
 		case "n":
@@ -266,22 +324,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "N":
 			m.prevFile()
-			return m, nil
-
-		// Toggle hide whitespace
-		case "w":
-			m.hideWhitespace = !m.hideWhitespace
-			return m, m.loadDiff()
-
-		// Adjust context lines
-		case "+", "=":
-			m.contextLines++
-			return m, m.loadDiff()
-		case "-", "_":
-			if m.contextLines > 0 {
-				m.contextLines--
-				return m, m.loadDiff()
-			}
 			return m, nil
 
 		// Report issue opens GitHub new issue page
@@ -601,17 +643,24 @@ func (m Model) updateFileList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		m.syncSelectedFile()
 		m.focus = focusDiffView
-	case "s", "S":
-		if cmd := m.stageCurrentFile(); cmd != nil {
-			return m, cmd
+	// Git-only keys — no-op in file review mode
+	case "s", "S", "u", "U", "D":
+		if m.fileReviewMode {
+			return m, nil
 		}
-	case "u", "U":
-		if cmd := m.unstageCurrentFile(); cmd != nil {
-			return m, cmd
-		}
-	case "D":
-		if cmd := m.discardCurrentFile(); cmd != nil {
-			return m, cmd
+		switch msg.String() {
+		case "s", "S":
+			if cmd := m.stageCurrentFile(); cmd != nil {
+				return m, cmd
+			}
+		case "u", "U":
+			if cmd := m.unstageCurrentFile(); cmd != nil {
+				return m, cmd
+			}
+		case "D":
+			if cmd := m.discardCurrentFile(); cmd != nil {
+				return m, cmd
+			}
 		}
 	case "c":
 		m.startFileComment()
@@ -645,25 +694,32 @@ func (m Model) updateDiffView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "d":
 		m.deleteCommentAtCursor()
-	case "s":
-		if cmd := m.stageCurrentHunk(); cmd != nil {
-			return m, cmd
+	// Git-only keys — no-op in file review mode
+	case "s", "u", "D", "S", "U":
+		if m.fileReviewMode {
+			return m, nil
 		}
-	case "u":
-		if cmd := m.unstageCurrentHunk(); cmd != nil {
-			return m, cmd
-		}
-	case "D":
-		if cmd := m.discardCurrentHunk(); cmd != nil {
-			return m, cmd
-		}
-	case "S":
-		if cmd := m.stageCurrentFile(); cmd != nil {
-			return m, cmd
-		}
-	case "U":
-		if cmd := m.unstageCurrentFile(); cmd != nil {
-			return m, cmd
+		switch msg.String() {
+		case "s":
+			if cmd := m.stageCurrentHunk(); cmd != nil {
+				return m, cmd
+			}
+		case "u":
+			if cmd := m.unstageCurrentHunk(); cmd != nil {
+				return m, cmd
+			}
+		case "D":
+			if cmd := m.discardCurrentHunk(); cmd != nil {
+				return m, cmd
+			}
+		case "S":
+			if cmd := m.stageCurrentFile(); cmd != nil {
+				return m, cmd
+			}
+		case "U":
+			if cmd := m.unstageCurrentFile(); cmd != nil {
+				return m, cmd
+			}
 		}
 	}
 	return m, nil
@@ -1190,12 +1246,17 @@ func (m Model) View() string {
 
 	statusBar := m.renderStatusBar()
 
+	slider := m.renderModeSlider()
+	if m.fileReviewMode {
+		slider = m.fileReviewPath
+	}
+
 	var screen string
 	if m.fullscreen {
-		panels := m.diffView.render(true, m.contextLines, m.hideWhitespace, m.renderModeSlider())
+		panels := m.diffView.render(true, m.contextLines, m.hideWhitespace, slider)
 		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
 	} else {
-		left := m.fileList.render(m.focus == focusFileList, m.renderModeSlider())
+		left := m.fileList.render(m.focus == focusFileList, slider)
 		right := m.diffView.render(m.focus == focusDiffView, m.contextLines, m.hideWhitespace)
 		panels := lipgloss.JoinHorizontal(lipgloss.Top, left, " ", right)
 		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
@@ -1206,8 +1267,18 @@ func (m Model) View() string {
 	}
 
 	if m.showHelp {
-		screen = overlayCenter(screen, renderHelp(m.width, m.height, m.helpScroll), m.width, m.height)
+		var helpBindings []BindingGroup
+		if m.fileReviewMode {
+			helpBindings = FileReviewBindingGroups()
+		}
+		screen = overlayCenter(screen, renderHelp(m.width, m.height, m.helpScroll, helpBindings), m.width, m.height)
 	}
 
 	return screen
+}
+
+// ExportedComments returns the formatted comment text for printing on exit.
+// Returns "" if there are no comments.
+func (m Model) ExportedComments() string {
+	return formatExport(m.diff.Files, m.comments)
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1520,3 +1520,154 @@ func TestPollInterval_IsAtLeast30Seconds(t *testing.T) {
 	assert.GreaterOrEqual(t, pollInterval, 30*time.Second,
 		"poll interval must be >= 30s to avoid I/O contention (see #129)")
 }
+
+// --- File review mode tests ---
+
+// makeFileReviewModel creates a file review mode model with context lines.
+func makeFileReviewModel(lines []git.Line) Model {
+	diff := &git.Diff{
+		Files: []git.FileDiff{{
+			Path:   "test.md",
+			Status: git.StatusModified,
+			Hunks:  []git.Hunk{{Lines: lines}},
+		}},
+	}
+	m := NewFileReview(diff, "test.md")
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	return updated.(Model)
+}
+
+func TestFileReviewMode_StartsFullscreenWithDiffFocus(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	assert.True(t, m.fullscreen)
+	assert.Equal(t, focusDiffView, m.focus)
+	assert.True(t, m.fileReviewMode)
+}
+
+func TestFileReviewMode_TabIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	mode := m.mode
+	m = sendSpecialKey(m, tea.KeyTab)
+	assert.Equal(t, mode, m.mode)
+}
+
+func TestFileReviewMode_PlusMinusAreNoops(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	ctx := m.contextLines
+	m = sendKey(m, "+")
+	assert.Equal(t, ctx, m.contextLines)
+	m = sendKey(m, "-")
+	assert.Equal(t, ctx, m.contextLines)
+}
+
+func TestFileReviewMode_StageKeyIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+}
+
+func TestFileReviewMode_UnstageKeyIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+}
+
+func TestFileReviewMode_DiscardKeyIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+	assert.False(t, m.confirmDiscard)
+}
+
+func TestFileReviewMode_WhitespaceToggleIsNoop(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	ws := m.hideWhitespace
+	m = sendKey(m, "w")
+	assert.Equal(t, ws, m.hideWhitespace)
+}
+
+func TestFileReviewMode_CommentStillWorks(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	require.NotNil(t, m.diffView.cursorRef())
+	m = sendKey(m, "c")
+	assert.True(t, m.commentInputActive)
+}
+
+func TestFileReviewMode_ExportedComments(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello world", OldNum: 1, NewNum: 1},
+	})
+	m.comments[commentKey{file: "test.md", lineNum: 1}] = "nice line"
+	text := m.ExportedComments()
+	assert.Contains(t, text, "# Code Review Comments")
+	assert.Contains(t, text, "test.md")
+	assert.Contains(t, text, "nice line")
+}
+
+func TestFileReviewMode_ExportedCommentsEmpty(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	assert.Empty(t, m.ExportedComments())
+}
+
+func TestFileReviewMode_HelpOmitsGitBindings(t *testing.T) {
+	groups := FileReviewBindingGroups()
+	for _, g := range groups {
+		for _, b := range g.Bindings {
+			assert.False(t, b.GitOnly, "help should not include git-only binding: %s", b.Key)
+		}
+		// File List group should be entirely filtered out
+		assert.NotEqual(t, "File List", g.Name)
+	}
+	// Verify specific git-only bindings are filtered
+	allKeys := ""
+	for _, g := range groups {
+		for _, b := range g.Bindings {
+			allKeys += b.Key + " "
+		}
+	}
+	assert.NotContains(t, allKeys, "Tab/S-Tab")
+	assert.NotContains(t, allKeys, "+/-")
+	assert.NotContains(t, allKeys, "← (h)")
+}
+
+func TestFileReviewMode_CannotExitFullscreen(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	require.True(t, m.fullscreen)
+	// Left arrow, f, esc should all keep fullscreen
+	m = sendKey(m, "h")
+	assert.True(t, m.fullscreen)
+	m = sendKey(m, "f")
+	assert.True(t, m.fullscreen)
+	m = sendSpecialKey(m, tea.KeyEsc)
+	assert.True(t, m.fullscreen)
+}
+
+func TestFileReviewMode_InitReturnsNil(t *testing.T) {
+	m := makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "hello", OldNum: 1, NewNum: 1},
+	})
+	assert.Nil(t, m.Init())
+}

--- a/main.go
+++ b/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/justincampbell/revise/internal/comments"
 	"github.com/justincampbell/revise/internal/git"
 	"github.com/justincampbell/revise/internal/ui"
@@ -15,7 +18,27 @@ import (
 
 var version = "dev"
 
+// ttyOut is the TUI output writer. Opened from /dev/tty so the TUI
+// renders to the terminal even when stdout is redirected.
+var ttyOut *os.File
+
+func init() {
+	// Open /dev/tty so the TUI renders to the real terminal even when
+	// stdout is redirected (enables piping and EDITOR workflows).
+	// Mutate the existing default renderer (don't replace it) so that
+	// styles already created by imported packages keep their reference.
+	var err error
+	ttyOut, err = os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		ttyOut = os.Stderr
+	}
+	r := lipgloss.DefaultRenderer()
+	r.SetOutput(termenv.NewOutput(ttyOut))
+}
+
 func main() {
+
+	outputFlag := flag.String("output", "", "Write comments to file on exit")
 	helpFlag := flag.Bool("help", false, "Show help")
 	versionFlag := flag.Bool("version", false, "Show version")
 	flag.BoolVar(versionFlag, "v", false, "Show version (shorthand)")
@@ -53,6 +76,12 @@ func main() {
 		case "styles":
 			ui.PrintStylesDemo()
 			return
+		case "diff":
+			// Handled below after git repo check.
+		default:
+			// Positional argument: file review mode.
+			runFileReview(args[0], *outputFlag)
+			return
 		}
 	}
 
@@ -68,15 +97,9 @@ func main() {
 	}
 
 	// Subcommands that require a git repo.
-	if len(args) > 0 {
-		switch args[0] {
-		case "diff":
-			runDiff()
-			return
-		default:
-			fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
-			os.Exit(1)
-		}
+	if len(args) > 0 && args[0] == "diff" {
+		runDiff()
+		return
 	}
 
 	onDefaultBranch, err := git.IsOnDefaultBranch()
@@ -107,12 +130,86 @@ func main() {
 	}
 
 	m := ui.NewWithStorePath(diff, onDefaultBranch, storePath, version)
-	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithReportFocus())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithReportFocus(), tea.WithOutput(ttyOut))
 
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Output comments on exit.
+	if fm, ok := finalModel.(ui.Model); ok {
+		writeComments(fm, *outputFlag)
+	}
+}
+
+func runFileReview(filePath string, outputPath string) {
+	diff, err := buildFileDiff(filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	m := ui.NewFileReview(diff, filePath)
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithOutput(ttyOut))
+	finalModel, err := p.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Output comments on exit.
+	if fm, ok := finalModel.(ui.Model); ok {
+		writeComments(fm, outputPath)
+	}
+}
+
+// writeComments outputs comments to --output file or stdout.
+func writeComments(m ui.Model, outputPath string) {
+	text := m.ExportedComments()
+	if text == "" {
+		return
+	}
+	if outputPath != "" {
+		if err := os.WriteFile(outputPath, []byte(text), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing comments: %v\n", err)
+		}
+		return
+	}
+	fmt.Print(text)
+}
+
+// buildFileDiff reads a file and returns a synthetic Diff for file review mode.
+func buildFileDiff(filePath string) (*git.Diff, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var lines []git.Line
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		lines = append(lines, git.Line{
+			Type:    git.LineContext,
+			Content: scanner.Text(),
+			OldNum:  lineNum,
+			NewNum:  lineNum,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return &git.Diff{
+		Files: []git.FileDiff{{
+			Path:   filePath,
+			Status: git.StatusModified,
+			Hunks:  []git.Hunk{{Lines: lines}},
+		}},
+	}, nil
 }
 
 func runDiff() {
@@ -154,15 +251,19 @@ func runUpdate(args []string) {
 func printHelp() {
 	fmt.Println(`revise - Review local git changes
 
-Usage: revise [flags] [command]
+Usage: revise [flags] [command] [file]
 
 Flags:
   --help                Show this help
   --version, -v         Show version
   --theme <name>        Color theme: dark (default), light, dark-daltonized, light-daltonized
+  --output <file>       Write comments to file on exit
 
 Commands:
   diff            Print unified diff (no TUI)
   styles          Show file status color matrix
-  update [--pre]  Update to the latest version`)
+  update [--pre]  Update to the latest version
+
+File review:
+  revise <file>   Review a file with comments`)
 }


### PR DESCRIPTION
## Summary

- `revise <file>` opens any file in read-only fullscreen review mode with comment support (#55, #119)
- Comments printed to stdout on exit, enabling integration with Claude Code (#118)
- `--output <file>` flag writes comments to a file instead of stdout
- TUI renders to /dev/tty with lipgloss renderer mutated in-place, so colors work even when stdout is redirected

## Details

**File review mode** — all lines shown as context (no diff coloring), starts fullscreen with diff focused. Git-specific keys (stage/unstage/discard, mode cycling, context lines, whitespace toggle) are no-ops, guarded by a single `fileReviewMode` check per key group. Help overlay and File List group filtered via `GitOnly` flag on `Binding`.

**Comment output** — `ExportedComments()` method on Model returns formatted markdown. Both git diff and file review modes print on exit. `--output <file>` writes to a file instead.

**/dev/tty rendering** — `init()` opens `/dev/tty` for bubbletea output and mutates the existing lipgloss default renderer (via `SetOutput`, not `SetDefaultRenderer`) so package-level styles retain their pointer and get color support.

## Test plan

- [x] `revise CLAUDE.md` — fullscreen, comments work, no git chrome
- [x] `revise` — normal git diff mode unchanged, comments print on exit
- [x] `revise --output /tmp/out.md <file>` — comments written to file
- [x] `tmux display-popup -E "revise <file> > /tmp/out.txt"` — TUI has color, stdout captured
- [x] `go test ./...` — 14 new tests, all passing
- [x] `revise nonexistent.txt` — shows error message

Closes #55, closes #118, closes #119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file review mode: use `revise <file>` to open any file in read-only mode with full comment support.
  * Comments can be exported to stdout or to a file using the `--output` flag.
  * Git-specific controls are disabled during file review.
  * TTY-based rendering ensures proper terminal output even when stdout is redirected.

* **Documentation**
  * Updated guides with file review mode instructions and keyboard bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->