### PR TITLE
Add linter for go.mod go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  gomod:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -17,6 +17,11 @@ jobs:
 
       - name: Check go.mod is tidy
         run: make lint-gomod
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
       - name: Lint
         uses: golangci/golangci-lint-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check go.mod is tidy
+        run: make lint-gomod
+
       - name: Lint
         uses: golangci/golangci-lint-action@v7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `make build` and `make install` produce a version-stamped copy (`revise@VERSION`) alongside `revise` for testing multiple versions side-by-side (#153)
 
+### Changed
+
+- Lowered `go.mod` go directive from `1.25.3` to `1.24.11` (actual minimum), added `toolchain` directive (#151)
+- Added `lint-gomod` check to verify `go.mod` stays tidy and go version doesn't drift (#151)
+
 ## [0.2.0] - 2026-03-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ make           # lint + test (default)
 make build     # build revise + revise@VERSION
 make install   # install revise + revise@VERSION to GOBIN
 make test      # go test ./...
-make lint      # golangci-lint
+make lint      # go.mod tidy check + golangci-lint
 make clean     # remove binaries
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LDFLAGS := -X main.version=$(VERSION)
 GOLANGCI_LINT_VERSION := v2.11.4
 GOBIN := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 
-.PHONY: all build install test lint clean
+.PHONY: all build install test lint lint-gomod clean
 
 all: lint test
 
@@ -19,8 +19,18 @@ install:
 test:
 	go test ./...
 
-lint:
+lint: lint-gomod
 	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...
+
+lint-gomod:
+	@cp go.mod go.mod.bak && cp go.sum go.sum.bak && \
+	go mod tidy && \
+	if ! diff -q go.mod go.mod.bak > /dev/null 2>&1; then \
+		echo "error: go.mod is not tidy (go version may have drifted). Run 'go mod tidy' and commit the result." >&2; \
+		mv go.mod.bak go.mod; mv go.sum.bak go.sum; \
+		exit 1; \
+	fi; \
+	mv go.sum.bak go.sum; rm -f go.mod.bak
 
 clean:
 	rm -f revise revise@*

--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,12 @@ lint: lint-gomod
 	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...
 
 lint-gomod:
-	@cp go.mod go.mod.bak && cp go.sum go.sum.bak && \
-	go mod tidy && \
-	if ! diff -q go.mod go.mod.bak > /dev/null 2>&1; then \
+	@go mod tidy && \
+	if [ -n "$$(git diff --name-only go.mod go.sum)" ]; then \
 		echo "error: go.mod is not tidy (go version may have drifted). Run 'go mod tidy' and commit the result." >&2; \
-		mv go.mod.bak go.mod; mv go.sum.bak go.sum; \
+		git checkout go.mod go.sum; \
 		exit 1; \
-	fi; \
-	mv go.sum.bak go.sum; rm -f go.mod.bak
+	fi
 
 clean:
 	rm -f revise revise@*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/justincampbell/revise
 
-go 1.25.3
+go 1.24.11
+
+toolchain go1.25.3
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0
@@ -8,6 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creativeprojects/go-selfupdate v1.5.2
+	github.com/muesli/termenv v0.16.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -38,7 +41,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect


### PR DESCRIPTION
## Summary

Lower the `go` directive in go.mod from `1.25.3` (developer's toolchain version) to `1.24.11` (actual minimum required by dependencies). Add a `toolchain` directive to specify the recommended build version separately.

Add a `lint-gomod` Make target that runs `go mod tidy` and verifies go.mod hasn't changed, catching accidental version bumps. Wire this into both `make lint` and CI.

Fixes #151

## Test plan

- [x] `make lint` passes locally
- [x] `make test` passes locally
- [x] Verified `lint-gomod` catches a wrong version (manually set `go 1.25.3` and confirmed it fails)
- [x] Update CHANGELOG.md if user-facing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated go.mod tidiness validation to CI and lint workflows to maintain module consistency.
  * Updated Go version requirements from 1.25.3 to 1.24.11 with enhanced toolchain directive support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->