### PR TITLE
Add version-stamped binary copy with @ separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 revise
+revise@*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `make build` and `make install` produce a version-stamped copy (`revise@VERSION`) alongside `revise` for testing multiple versions side-by-side (#153)
+
 ## [0.2.0] - 2026-03-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,12 +86,14 @@ r.StatusPorcelain()          // git status --porcelain
 
 ```sh
 make           # lint + test (default)
-make build     # build binary
-make install   # lint + test, then go install
+make build     # build revise + revise@VERSION
+make install   # install revise + revise@VERSION to GOBIN
 make test      # go test ./...
 make lint      # golangci-lint
-make clean     # remove binary
+make clean     # remove binaries
 ```
+
+`make build` and `make install` produce two binaries: `revise` (for normal use) and `revise@VERSION` (e.g. `revise@v0.2.0` on a tag, `revise@v0.2.0-gb18a73d` on a dev build). The versioned copy lets you keep and compare specific builds side-by-side.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION ?= $(shell git describe --tags --dirty --always | sed 's/-[0-9]*-g/-g/')
 LDFLAGS := -X main.version=$(VERSION)
 GOLANGCI_LINT_VERSION := v2.11.4
+GOBIN := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 
 .PHONY: all build install test lint clean
 
@@ -8,9 +9,12 @@ all: lint test
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o revise .
+	cp revise "revise@$(VERSION)"
 
 install:
-	go install -ldflags "$(LDFLAGS)" .
+	go build -ldflags "$(LDFLAGS)" -o "$(GOBIN)/revise" .
+	cp "$(GOBIN)/revise" "$(GOBIN)/revise@$(VERSION)"
+	@echo "Installed $(GOBIN)/revise and $(GOBIN)/revise@$(VERSION)"
 
 test:
 	go test ./...
@@ -19,4 +23,4 @@ lint:
 	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...
 
 clean:
-	rm -f revise
+	rm -f revise revise@*


### PR DESCRIPTION
## Summary

`make build` and `make install` now produce two binaries:
- `revise` — for normal use
- `revise@VERSION` — version-stamped copy for side-by-side comparison

The version in the binary name matches `revise --version` output:
- On tag: `revise@v0.2.0`
- Dev build: `revise@v0.2.0-gb18a73d`

## Test plan

- `make build` produces `./revise` and `./revise@VERSION`
- `make install` installs both to `$GOBIN`
- `./revise@VERSION --version` output matches the `@` suffix
- `make clean` removes both
- CI unaffected (uses `go build ./...` directly)
- goreleaser releases unaffected

- [x] Update CHANGELOG.md if user-facing

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `make build` and `make install` now create version-stamped binary copies alongside the standard binary, enabling side-by-side testing of multiple versions.

* **Documentation**
  * Updated build and installation documentation to reflect new versioning behavior.

* **Chores**
  * Updated build system configuration and ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->