### PR TITLE
Do not allow viewing binary diffs

### DIFF
--- a/internal/git/diff_integration_test.go
+++ b/internal/git/diff_integration_test.go
@@ -656,6 +656,30 @@ func TestUntrackedFiles_TaggedAsUnstaged(t *testing.T) {
 	assert.Equal(t, SourceUnstaged, f.Hunks[0].Source)
 }
 
+func TestUntrackedFiles_BinaryDetected(t *testing.T) {
+	r := baseRepo(t)
+	// Write a file with null bytes (binary content)
+	full := r.Dir + "/image.png"
+	if err := os.WriteFile(full, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	InvalidateUntrackedCache()
+	files, err := UntrackedFiles()
+	require.NoError(t, err)
+
+	var found *FileDiff
+	for i := range files {
+		if files[i].Path == "image.png" {
+			found = &files[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected image.png in untracked files")
+	assert.True(t, found.IsBinary, "expected image.png to be marked as binary")
+	assert.Empty(t, found.Hunks, "binary files should have no hunks")
+}
+
 // ============================================================================
 // Hide whitespace
 // ============================================================================

--- a/internal/git/parse.go
+++ b/internal/git/parse.go
@@ -60,6 +60,12 @@ func Parse(raw string) *Diff {
 			continue
 		}
 
+		// Detect binary files
+		if strings.HasPrefix(line, "Binary files ") {
+			currentFile.IsBinary = true
+			continue
+		}
+
 		// Skip index, --- and +++ lines
 		if strings.HasPrefix(line, "index ") ||
 			strings.HasPrefix(line, "--- ") ||

--- a/internal/git/parse_test.go
+++ b/internal/git/parse_test.go
@@ -144,6 +144,60 @@ func TestParseRenamedFile(t *testing.T) {
 	assert.Equal(t, "new.go", f.Path)
 }
 
+const binaryFileDiff = `diff --git a/image.png b/image.png
+new file mode 100644
+index 0000000..abc1234
+Binary files /dev/null and b/image.png differ
+`
+
+func TestParseBinaryFile(t *testing.T) {
+	diff := Parse(binaryFileDiff)
+
+	require.Len(t, diff.Files, 1)
+	f := diff.Files[0]
+	assert.Equal(t, "image.png", f.Path)
+	assert.True(t, f.IsBinary, "expected IsBinary to be true")
+	assert.Empty(t, f.Hunks, "binary files should have no hunks")
+}
+
+const binaryModifiedDiff = `diff --git a/image.png b/image.png
+index abc1234..def5678 100644
+Binary files a/image.png and b/image.png differ
+`
+
+func TestParseBinaryModifiedFile(t *testing.T) {
+	diff := Parse(binaryModifiedDiff)
+
+	require.Len(t, diff.Files, 1)
+	f := diff.Files[0]
+	assert.Equal(t, "image.png", f.Path)
+	assert.True(t, f.IsBinary)
+	assert.Equal(t, StatusModified, f.Status)
+}
+
+const mixedBinaryAndTextDiff = `diff --git a/image.png b/image.png
+new file mode 100644
+index 0000000..abc1234
+Binary files /dev/null and b/image.png differ
+diff --git a/main.go b/main.go
+index abc1234..def5678 100644
+--- a/main.go
++++ b/main.go
+@@ -1,3 +1,4 @@
+ package main
++import "os"
+ func main() {}
+`
+
+func TestParseMixedBinaryAndText(t *testing.T) {
+	diff := Parse(mixedBinaryAndTextDiff)
+
+	require.Len(t, diff.Files, 2)
+	assert.True(t, diff.Files[0].IsBinary, "image.png should be binary")
+	assert.False(t, diff.Files[1].IsBinary, "main.go should not be binary")
+	assert.Len(t, diff.Files[1].Hunks, 1)
+}
+
 func TestParseLineNumbers(t *testing.T) {
 	diff := Parse(sampleDiff)
 	h := diff.Files[0].Hunks[0]

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -18,10 +18,11 @@ const (
 
 // FileDiff represents the diff for a single file.
 type FileDiff struct {
-	Path    string
-	OldPath string // for renames
-	Status  FileStatus
-	Hunks   []Hunk
+	Path     string
+	OldPath  string // for renames
+	Status   FileStatus
+	IsBinary bool
+	Hunks    []Hunk
 }
 
 // HunkSource identifies where a hunk came from.

--- a/internal/git/untracked.go
+++ b/internal/git/untracked.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,6 +51,16 @@ func UntrackedFiles() ([]FileDiff, error) {
 
 		content, err := os.ReadFile(path)
 		if err != nil {
+			continue
+		}
+
+		// Detect binary files by checking for null bytes (same heuristic as git)
+		if bytes.ContainsRune(content, 0) {
+			files = append(files, FileDiff{
+				Path:     path,
+				Status:   StatusUntracked,
+				IsBinary: true,
+			})
 			continue
 		}
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -79,6 +79,12 @@ func (m *diffViewModel) buildLines() {
 		m.lineRefs = append(m.lineRefs, ref)
 	}
 
+	// Binary files: show a placeholder instead of diff content.
+	if m.file.IsBinary {
+		add("  Binary file — cannot display diff", nil)
+		return
+	}
+
 	// Show file-level comment (lineNum == 0) at the top if one exists.
 	fileKey := commentKey{file: m.file.Path, lineNum: 0}
 	if text, ok := m.comments[fileKey]; ok {

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -586,6 +586,33 @@ func stripANSI(s string) string {
 	return ansi.Strip(s)
 }
 
+func TestBuildLines_BinaryFile(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 40
+	m.height = 10
+	m.file = &git.FileDiff{
+		Path:     "image.png",
+		IsBinary: true,
+	}
+	m.buildLines()
+	// Should show a binary file message, not an empty diff
+	require.NotEmpty(t, m.lines)
+	found := false
+	for _, line := range m.lines {
+		if strings.Contains(line, "Binary file") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected 'Binary file' message in lines: %v", m.lines)
+	// No navigable lines for binary files
+	for i, ref := range m.lineRefs {
+		if ref != nil && !ref.isCommentDisplay {
+			t.Errorf("expected no navigable lines for binary file, but line %d has ref %+v", i, ref)
+		}
+	}
+}
+
 func TestSetBorderBottomCounts_SlashColumnFixed(t *testing.T) {
 	// The slash should always appear at the same column regardless of
 	// digit counts in the added/removed numbers.


### PR DESCRIPTION
## Summary

Detect binary files and show a placeholder message ("Binary file — cannot display diff") instead of rendering garbled content in the diff view. Binary detection in three places:
- **Parser**: recognizes the `Binary files ... differ` line from `git diff` output
- **Untracked files**: checks for null bytes (same heuristic as git)
- **Diff view**: shows placeholder text with no navigable lines

Fixes #154

## Test plan

- Open revise with a binary file in the diff (e.g. untracked .png)
- Verify the file appears in the file list but shows "Binary file — cannot display diff" in the diff pane
- Verify text files still render normally
- `make test` passes

- [ ] Update CHANGELOG.md if user-facing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic detection of binary files in diffs and untracked files.
  * Binary files now display a placeholder message in the UI instead of attempting to render diff content.

* **Tests**
  * Added comprehensive test coverage for binary file detection and display scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->