### PR TITLE
Support git's core.untrackedCache for faster refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `setup-cache` subcommand to enable git's `core.untrackedCache` for faster refreshes; a startup tip surfaces in the status bar when the cache is disabled but the filesystem supports it (#160)
+
 ## [0.3.0] - 2026-04-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Comments are also output on exit in normal git diff mode.
 | Command | Description |
 |---------|-------------|
 | `revise <file>` | Review a file with comments |
+| `revise setup-cache` | Enable git's `core.untrackedCache` for faster refreshes |
 | `revise styles` | Show file status color matrix for all staging states |
 | `revise update [--pre]` | Update to the latest version |
 

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -1,0 +1,44 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// UntrackedCacheEnabled reports whether git's core.untrackedCache is enabled
+// for the current repo. A missing config key is treated as not enabled.
+// The untracked cache speeds up `git status` by caching directory mtimes —
+// enabling it makes revise's polling loop noticeably faster on large repos.
+func UntrackedCacheEnabled() bool {
+	out, err := exec.Command("git", "config", "--get", "core.untrackedCache").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
+}
+
+// TestUntrackedCacheSupport runs git's built-in filesystem self-test.
+// Returns nil if the filesystem reliably updates directory mtimes (required
+// for the untracked cache), or an error otherwise. The test has small,
+// transient filesystem side effects and should be treated as a one-shot check.
+func TestUntrackedCacheSupport() error {
+	cmd := exec.Command("git", "update-index", "--test-untracked-cache")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("filesystem does not support the untracked cache: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// EnableUntrackedCache sets core.untrackedCache=true in the current repo's
+// local config. Local scope, not --global — we never modify the user's global
+// git config implicitly.
+func EnableUntrackedCache() error {
+	cmd := exec.Command("git", "config", "core.untrackedCache", "true")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git config core.untrackedCache: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -1,0 +1,49 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUntrackedCacheEnabled_NotSet(t *testing.T) {
+	r := NewTestRepo(t)
+	r.Chdir()
+	assert.False(t, UntrackedCacheEnabled(), "unset config should read as disabled")
+}
+
+func TestUntrackedCacheEnabled_SetTrue(t *testing.T) {
+	r := NewTestRepo(t)
+	r.mustGit("config", "core.untrackedCache", "true")
+	r.Chdir()
+	assert.True(t, UntrackedCacheEnabled())
+}
+
+func TestUntrackedCacheEnabled_SetFalse(t *testing.T) {
+	r := NewTestRepo(t)
+	r.mustGit("config", "core.untrackedCache", "false")
+	r.Chdir()
+	assert.False(t, UntrackedCacheEnabled())
+}
+
+func TestEnableUntrackedCache_SetsConfig(t *testing.T) {
+	r := NewTestRepo(t)
+	r.Chdir()
+
+	require.NoError(t, EnableUntrackedCache())
+	assert.True(t, UntrackedCacheEnabled())
+	assert.Equal(t, "true", r.mustGit("config", "--get", "core.untrackedCache"))
+}
+
+// The self-test has real filesystem side effects. On dev platforms (macOS,
+// modern Linux) the temp dir should support untracked cache. If this test
+// fails on CI, the CI filesystem doesn't support it — skip rather than fail.
+func TestUntrackedCacheSupport_OnSupportedFilesystem(t *testing.T) {
+	r := NewTestRepo(t)
+	r.Chdir()
+
+	if err := TestUntrackedCacheSupport(); err != nil {
+		t.Skipf("filesystem at %s does not support untracked cache: %v", r.Dir, err)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -39,6 +39,10 @@ type updateCheckMsg struct {
 	err  error
 }
 
+// untrackedCacheTipMsg fires if the repo has core.untrackedCache disabled
+// and the filesystem supports enabling it — we surface a one-time tip.
+type untrackedCacheTipMsg struct{}
+
 // updateAppliedMsg is sent when an update download+install completes.
 type updateAppliedMsg struct {
 	newVersion string
@@ -214,6 +218,15 @@ func (m Model) Init() tea.Cmd {
 			return updateCheckMsg{info: info, err: err}
 		})
 	}
+	cmds = append(cmds, func() tea.Msg {
+		if git.UntrackedCacheEnabled() {
+			return nil
+		}
+		if git.TestUntrackedCacheSupport() != nil {
+			return nil
+		}
+		return untrackedCacheTipMsg{}
+	})
 	return tea.Batch(cmds...)
 }
 
@@ -586,6 +599,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			fp, err := git.StatusFingerprint()
 			return pollResultMsg{fingerprint: fp, err: err}
 		}
+
+	case untrackedCacheTipMsg:
+		m.statusMsg = "Tip: enable core.untrackedCache for faster refresh — run 'revise setup-cache'"
+		return m, tea.Tick(10*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
 
 	case updateCheckMsg:
 		if msg.err == nil && msg.info != nil && msg.info.IsNewer {

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 		case "styles":
 			ui.PrintStylesDemo()
 			return
-		case "diff":
+		case "diff", "setup-cache":
 			// Handled below after git repo check.
 		default:
 			// Positional argument: file review mode.
@@ -101,6 +101,10 @@ func main() {
 	// Subcommands that require a git repo.
 	if len(args) > 0 && args[0] == "diff" {
 		runDiff()
+		return
+	}
+	if len(args) > 0 && args[0] == "setup-cache" {
+		runSetupCache()
 		return
 	}
 
@@ -224,6 +228,22 @@ func runDiff() {
 	fmt.Print(git.Format(diff))
 }
 
+func runSetupCache() {
+	if git.UntrackedCacheEnabled() {
+		fmt.Println("core.untrackedCache is already enabled")
+		return
+	}
+	if err := git.TestUntrackedCacheSupport(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := git.EnableUntrackedCache(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("enabled core.untrackedCache for this repo")
+}
+
 func runUpdate(args []string) {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 	pre := fs.Bool("pre", false, "Include pre-release (dev) builds")
@@ -268,6 +288,7 @@ Flags:
 
 Commands:
   diff            Print unified diff (no TUI)
+  setup-cache     Enable git's core.untrackedCache for faster refreshes
   styles          Show file status color matrix
   update [--pre]  Update to the latest version
 


### PR DESCRIPTION
## Summary

- Adds `revise setup-cache` subcommand that runs `git update-index --test-untracked-cache` and, if the filesystem supports it, sets `core.untrackedCache=true` in the local repo
- Adds a one-time startup tip in the status bar when the cache is disabled but the filesystem supports it, pointing to the new subcommand
- `core.untrackedCache` caches directory mtimes in the index and speeds up `git status` — which is what revise's 30s polling loop calls on every tick. Biggest expected win for #144 (slow refresh)

## Design notes

- Never modifies global git config. The subcommand writes only the local repo config, and only after the filesystem self-test passes.
- The startup tip is silent if the filesystem doesn't support the cache (old network mounts, some FUSE) — no false alarms.
- The self-test has real filesystem side effects so we only run it once at startup; if disabled, we surface the tip once per session (auto-clears after 10s).

## Test plan

- [x] `make` passes (lint + test)
- [x] Unit tests for `UntrackedCacheEnabled`/`EnableUntrackedCache`/`TestUntrackedCacheSupport` using TestRepo
- [x] Manual: `revise setup-cache` in a fresh repo enables the config; running again reports "already enabled"
- [ ] Manual: launching `revise` in a repo without the cache shows the status bar tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `setup-cache` subcommand to enable Git's untracked cache feature, improving repository refresh performance
  * Added status bar tip that suggests enabling untracked cache when the filesystem supports it but it's currently disabled

* **Documentation**
  * Updated documentation with information about the new `setup-cache` subcommand

<!-- end of auto-generated comment: release notes by coderabbit.ai -->