### PR TITLE
Add --dev flag to auto-restart on binary replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `--dev` flag auto-restarts the running TUI when the binary is replaced (e.g. by `make install`), preserving argv and env (#160)
 - `setup-cache` subcommand to enable git's `core.untrackedCache` for faster refreshes; a startup tip surfaces in the status bar when the cache is disabled but the filesystem supports it (#160)
 
 ## [0.3.0] - 2026-04-15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,9 @@ internal/
   comments/
     store.go                   # JSON persistence for comments (Save/Load/StorePath)
     store_test.go              # persistence unit tests
+  devwatch/
+    devwatch.go                # poll a binary for changes, fire callback on replacement (--dev flag)
+    devwatch_test.go           # watcher unit tests
   update/
     update.go                  # self-update via go-selfupdate (CheckForUpdate, ApplyUpdate)
     update_test.go             # integration tests (skipped in short mode)

--- a/internal/devwatch/devwatch.go
+++ b/internal/devwatch/devwatch.go
@@ -1,0 +1,74 @@
+// Package devwatch polls a binary file for changes and invokes a callback
+// when it is replaced. Used to support the --dev flag, which auto-restarts
+// the running TUI when a freshly-built binary is installed.
+package devwatch
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+// DefaultInterval is how often Watcher checks the binary by default.
+const DefaultInterval = 500 * time.Millisecond
+
+// Watcher polls a single file for modifications.
+type Watcher struct {
+	Path     string
+	Interval time.Duration
+	OnChange func()
+}
+
+// New returns a Watcher for the given path. OnChange is invoked exactly
+// once, the first time a change is detected after Run starts.
+func New(path string, onChange func()) *Watcher {
+	return &Watcher{
+		Path:     path,
+		Interval: DefaultInterval,
+		OnChange: onChange,
+	}
+}
+
+// Run blocks, polling for changes, until ctx is cancelled or a change is
+// detected and OnChange has been called. If the file cannot be stat-ed at
+// startup, Run returns immediately.
+func (w *Watcher) Run(ctx context.Context) {
+	initial, err := stat(w.Path)
+	if err != nil {
+		return
+	}
+	ticker := time.NewTicker(w.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			current, err := stat(w.Path)
+			if err != nil {
+				continue
+			}
+			if changed(initial, current) {
+				w.OnChange()
+				return
+			}
+		}
+	}
+}
+
+type fileSig struct {
+	modTime time.Time
+	size    int64
+}
+
+func stat(path string) (fileSig, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fileSig{}, err
+	}
+	return fileSig{modTime: info.ModTime(), size: info.Size()}, nil
+}
+
+func changed(a, b fileSig) bool {
+	return !a.modTime.Equal(b.modTime) || a.size != b.size
+}

--- a/internal/devwatch/devwatch_test.go
+++ b/internal/devwatch/devwatch_test.go
@@ -1,0 +1,158 @@
+package devwatch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWatcherFiresOnModTimeChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bin")
+	if err := os.WriteFile(path, []byte("v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Bool
+	w := New(path, func() { fired.Store(true) })
+	w.Interval = 10 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go w.Run(ctx)
+
+	// Give the watcher time to record initial state.
+	time.Sleep(50 * time.Millisecond)
+
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if fired.Load() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("watcher did not fire on mtime change")
+}
+
+func TestWatcherFiresOnReplacement(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bin")
+	if err := os.WriteFile(path, []byte("v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Bool
+	w := New(path, func() { fired.Store(true) })
+	w.Interval = 10 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go w.Run(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Simulate `mv newbin path` — write a different size to a sibling, then rename over.
+	tmp := filepath.Join(dir, "bin.new")
+	if err := os.WriteFile(tmp, []byte("v2-larger"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if fired.Load() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("watcher did not fire on replacement")
+}
+
+func TestWatcherDoesNotFireWithoutChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bin")
+	if err := os.WriteFile(path, []byte("v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Bool
+	w := New(path, func() { fired.Store(true) })
+	w.Interval = 10 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	if fired.Load() {
+		t.Fatal("watcher fired without any change")
+	}
+}
+
+func TestWatcherStopsOnContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bin")
+	if err := os.WriteFile(path, []byte("v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w := New(path, func() { t.Fatal("callback should not fire") })
+	w.Interval = 10 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not stop after context cancel")
+	}
+}
+
+func TestWatcherFiresOnlyOnce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bin")
+	if err := os.WriteFile(path, []byte("v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var count atomic.Int32
+	w := New(path, func() { count.Add(1) })
+	w.Interval = 10 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	go w.Run(ctx)
+
+	time.Sleep(30 * time.Millisecond)
+
+	// Two distinct changes.
+	for i := 0; i < 2; i++ {
+		future := time.Now().Add(time.Duration(i+1) * time.Hour)
+		if err := os.Chtimes(path, future, future); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	<-ctx.Done()
+	if got := count.Load(); got != 1 {
+		t.Fatalf("callback fired %d times; want 1", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"charm.land/lipgloss/v2"
 	"github.com/justincampbell/revise/internal/comments"
+	"github.com/justincampbell/revise/internal/devwatch"
 	"github.com/justincampbell/revise/internal/git"
 	"github.com/justincampbell/revise/internal/ui"
 	"github.com/justincampbell/revise/internal/update"
@@ -38,6 +43,7 @@ func main() {
 	versionFlag := flag.Bool("version", false, "Show version")
 	flag.BoolVar(versionFlag, "v", false, "Show version (shorthand)")
 	themeFlag := flag.String("theme", "auto", "Color theme: auto, auto-daltonized, charmtone-dark, charmtone-dark-daltonized, charmtone-light, charmtone-light-daltonized, github-dark, github-dark-daltonized, github-light, github-light-daltonized")
+	devFlag := flag.Bool("dev", false, "Auto-restart when the binary is replaced (for local development)")
 	flag.Parse()
 
 	if *helpFlag {
@@ -82,7 +88,7 @@ func main() {
 			// Handled below after git repo check.
 		default:
 			// Positional argument: file review mode.
-			runFileReview(args[0], *outputFlag)
+			runFileReview(args[0], *outputFlag, *devFlag)
 			return
 		}
 	}
@@ -138,7 +144,7 @@ func main() {
 	m := ui.NewWithStorePath(diff, onDefaultBranch, storePath, version)
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithReportFocus(), tea.WithOutput(ttyOut))
 
-	finalModel, err := p.Run()
+	finalModel, err := runProgram(p, *devFlag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -150,7 +156,7 @@ func main() {
 	}
 }
 
-func runFileReview(filePath string, outputPath string) {
+func runFileReview(filePath string, outputPath string, devMode bool) {
 	diff, err := buildFileDiff(filePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -158,7 +164,7 @@ func runFileReview(filePath string, outputPath string) {
 	}
 	m := ui.NewFileReview(diff, filePath)
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithOutput(ttyOut))
-	finalModel, err := p.Run()
+	finalModel, err := runProgram(p, devMode)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -168,6 +174,42 @@ func runFileReview(filePath string, outputPath string) {
 	if fm, ok := finalModel.(ui.Model); ok {
 		writeComments(fm, outputPath)
 	}
+}
+
+// runProgram runs a Bubbletea program. When devMode is true, it polls the
+// running binary for changes and re-execs the process when the binary is
+// replaced (e.g. after `make install`), preserving the original argv and env.
+func runProgram(p *tea.Program, devMode bool) (tea.Model, error) {
+	var (
+		restart  atomic.Bool
+		selfPath string
+	)
+	if devMode {
+		if exe, err := os.Executable(); err == nil {
+			if real, err := filepath.EvalSymlinks(exe); err == nil {
+				selfPath = real
+			} else {
+				selfPath = exe
+			}
+		}
+		if selfPath != "" {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			w := devwatch.New(selfPath, func() {
+				restart.Store(true)
+				p.Quit()
+			})
+			go w.Run(ctx)
+		}
+	}
+
+	finalModel, err := p.Run()
+	if restart.Load() && selfPath != "" {
+		// Re-exec the (now-updated) binary in place. On success, this never
+		// returns; on failure, fall through and surface the original result.
+		_ = syscall.Exec(selfPath, os.Args, os.Environ())
+	}
+	return finalModel, err
 }
 
 // writeComments outputs comments to --output file or stdout.
@@ -285,6 +327,7 @@ Flags:
                           github-dark, github-dark-daltonized
                           github-light, github-light-daltonized
   --output <file>       Write comments to file on exit
+  --dev                 Auto-restart when the binary is replaced (development)
 
 Commands:
   diff            Print unified diff (no TUI)


### PR DESCRIPTION
## Summary

- Adds `--dev` flag that polls the running binary (mtime + size, 500ms interval) and re-execs in place when it's replaced -- so `make install` from another terminal swaps the running TUI to the new build without losing the session
- New `internal/devwatch/` package isolates the polling logic and is unit-tested for mtime change, atomic-rename replacement, no-change idle, context cancel, and fire-only-once
- Re-exec uses `syscall.Exec(selfPath, os.Args, os.Environ())` after Bubbletea cleans up the alt-screen, so argv and env are preserved

## Design notes

- Polling instead of fsnotify: avoids a new dependency; 500ms latency is fine for a dev convenience flag
- Resolves the binary via `os.Executable` + `EvalSymlinks` so symlinked installs (e.g. `$GOBIN/revise`) restart the right file
- Wired into both the main TUI path and `runFileReview` via a shared `runProgram` helper

## Test plan

- [x] `make` passes (lint + test)
- [x] Manual: `revise --dev` running while `make install` from another shell -- TUI restarts in place

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
