### PR TITLE
Horizontal scroll in diff view (right arrow no longer exits fullscreen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `--dev` flag auto-restarts the running TUI when the binary is replaced (e.g. by `make install`), preserving argv and env (#160)
 - `setup-cache` subcommand to enable git's `core.untrackedCache` for faster refreshes; a startup tip surfaces in the status bar when the cache is disabled but the filesystem supports it (#160)
+- Horizontal scroll in the diff view via →/← (or h/l) and mouse wheel left/right (#121)
+
+### Changed
+
+- Right arrow no longer toggles fullscreen — it scrolls right when the diff is focused. Use `f` to toggle fullscreen. Left arrow scrolls left first, then falls back to focusing the file list when already at column 0 (#121)
 
 ## [0.3.0] - 2026-04-15
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -34,7 +34,8 @@ type diffViewModel struct {
 	lines    []string   // pre-rendered display lines
 	lineRefs []*lineRef // parallel to lines
 	cursor   int        // absolute index into lines[]
-	offset   int        // scroll offset
+	offset   int        // vertical scroll offset (top line index)
+	hOffset  int        // horizontal scroll offset (columns clipped from the left)
 	height   int
 	width    int
 	comments comments
@@ -60,6 +61,7 @@ func (m *diffViewModel) setFile(f *git.FileDiff) {
 	m.file = f
 	m.cursor = 0
 	m.offset = 0
+	m.hOffset = 0
 	m.buildLines()
 	m.goToFirstNavigable()
 }
@@ -266,6 +268,45 @@ func (m *diffViewModel) scrollDown(n int) {
 		m.offset = max
 	}
 	m.clampCursorToView()
+}
+
+// viewWidth returns the width available for a rendered line's content,
+// excluding the panel border and cursor prefix column.
+func (m *diffViewModel) viewWidth() int {
+	w := m.width - 3 // border (2) + cursor prefix (1)
+	if w < 1 {
+		w = 1
+	}
+	return w
+}
+
+// maxHScroll returns the largest hOffset that keeps some content visible.
+func (m *diffViewModel) maxHScroll() int {
+	maxW := 0
+	for _, line := range m.lines {
+		if w := ansi.StringWidth(line); w > maxW {
+			maxW = w
+		}
+	}
+	max := maxW - m.viewWidth()
+	if max < 0 {
+		return 0
+	}
+	return max
+}
+
+func (m *diffViewModel) scrollRight(n int) {
+	m.hOffset += n
+	if max := m.maxHScroll(); m.hOffset > max {
+		m.hOffset = max
+	}
+}
+
+func (m *diffViewModel) scrollLeft(n int) {
+	m.hOffset -= n
+	if m.hOffset < 0 {
+		m.hOffset = 0
+	}
 }
 
 func (m *diffViewModel) goToTop() {
@@ -509,13 +550,13 @@ const inputBoxHeight = 3 // border top + content + border bottom
 
 func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace bool, modeSlider ...string) string {
 	viewH := m.viewHeight()
-	maxWidth := m.width - 3 // panel border (2) + cursor prefix (1)
-	if maxWidth < 1 {
-		maxWidth = 1
-	}
+	maxWidth := m.viewWidth()
 
 	renderLine := func(absIdx int) string {
 		line := m.lines[absIdx]
+		if m.hOffset > 0 {
+			line = ansi.TruncateLeft(line, m.hOffset, "")
+		}
 		if ansi.StringWidth(line) > maxWidth {
 			line = ansi.Truncate(line, maxWidth, "")
 		}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -551,11 +551,17 @@ const inputBoxHeight = 3 // border top + content + border bottom
 func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace bool, modeSlider ...string) string {
 	viewH := m.viewHeight()
 	maxWidth := m.viewWidth()
+	// Clamp a stale offset (e.g. after a resize or a shorter refreshed diff)
+	// so a scroll position from a wider state doesn't over-truncate now.
+	hOffset := m.hOffset
+	if max := m.maxHScroll(); hOffset > max {
+		hOffset = max
+	}
 
 	renderLine := func(absIdx int) string {
 		line := m.lines[absIdx]
-		if m.hOffset > 0 {
-			line = ansi.TruncateLeft(line, m.hOffset, "")
+		if hOffset > 0 {
+			line = ansi.TruncateLeft(line, hOffset, "")
 		}
 		if ansi.StringWidth(line) > maxWidth {
 			line = ansi.Truncate(line, maxWidth, "")

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -23,6 +23,65 @@ func makeDiffViewModel(lineCount, height int) diffViewModel {
 	return m
 }
 
+func TestDiffViewScrollRight_Clamps(t *testing.T) {
+	m := makeDiffViewModel(3, 10)
+	m.width = 20 // viewWidth = 17
+	m.lines[0] = strings.Repeat("a", 30)
+	// max = 30 - 17 = 13
+	m.scrollRight(100)
+	assert.Equal(t, 13, m.hOffset)
+}
+
+func TestDiffViewScrollRight_NoScrollWhenContentFits(t *testing.T) {
+	m := makeDiffViewModel(3, 10)
+	m.width = 50
+	m.lines[0] = "short"
+	m.scrollRight(10)
+	assert.Equal(t, 0, m.hOffset)
+}
+
+func TestDiffViewScrollLeft_Clamps(t *testing.T) {
+	m := makeDiffViewModel(3, 10)
+	m.hOffset = 5
+	m.scrollLeft(100)
+	assert.Equal(t, 0, m.hOffset)
+}
+
+func TestDiffViewSetFile_ResetsHOffset(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 40
+	m.hOffset = 10
+	m.setFile(&git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "hi", NewNum: 1}},
+		}},
+	})
+	assert.Equal(t, 0, m.hOffset)
+}
+
+func TestDiffViewRender_AppliesHOffset(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 20
+	m.height = 5
+	m.file = &git.FileDiff{
+		Path: "foo.go",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineAdded, Content: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", NewNum: 1}},
+		}},
+	}
+	m.buildLines()
+	m.goToFirstNavigable()
+
+	before := ansi.Strip(m.render(true, 3, false))
+	m.hOffset = 10
+	after := ansi.Strip(m.render(true, 3, false))
+	// With hOffset, the rendered content should shift — fewer leading 'A' chars visible.
+	assert.NotEqual(t, before, after, "render should change when hOffset changes")
+}
+
 func TestDiffViewScrollDown_Clamps(t *testing.T) {
 	m := makeDiffViewModel(10, 6) // viewHeight = 6, max offset = 4
 	m.scrollDown(100)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -17,8 +17,8 @@ type BindingGroup struct {
 // The help overlay and --help output are generated from this list.
 var allBindings = []BindingGroup{
 	{"General", []Binding{
-		{Key: "← (h)", Desc: "Focus file list", GitOnly: true},
-		{Key: "→ (l)", Desc: "Focus diff view", GitOnly: true},
+		{Key: "← (h)", Desc: "Focus file list / scroll left", GitOnly: true},
+		{Key: "→ (l)", Desc: "Focus diff view / scroll right", GitOnly: true},
 		{Key: "n/N", Desc: "Next/prev file", GitOnly: true},
 		{Key: "Tab/S-Tab", Desc: "Cycle diff mode", GitOnly: true},
 		{Key: "f", Desc: "Toggle fullscreen diff", GitOnly: true},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -17,8 +17,8 @@ type BindingGroup struct {
 // The help overlay and --help output are generated from this list.
 var allBindings = []BindingGroup{
 	{"General", []Binding{
-		{Key: "← (h)", Desc: "Focus file list / scroll left", GitOnly: true},
-		{Key: "→ (l)", Desc: "Focus diff view / scroll right", GitOnly: true},
+		{Key: "← (h)", Desc: "Focus file list", GitOnly: true},
+		{Key: "→ (l)", Desc: "Focus diff view", GitOnly: true},
 		{Key: "n/N", Desc: "Next/prev file", GitOnly: true},
 		{Key: "Tab/S-Tab", Desc: "Cycle diff mode", GitOnly: true},
 		{Key: "f", Desc: "Toggle fullscreen diff", GitOnly: true},
@@ -36,6 +36,7 @@ var allBindings = []BindingGroup{
 		{Key: "D", Desc: "Discard file", GitOnly: true},
 	}},
 	{"Diff View", []Binding{
+		{Key: "←/→ (h/l)", Desc: "Scroll horizontally"},
 		{Key: "j/k, ↑/↓", Desc: "Move cursor"},
 		{Key: "}/{ (]/[)", Desc: "Next/prev hunk"},
 		{Key: "+/-", Desc: "More/fewer context lines", GitOnly: true},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -78,6 +78,9 @@ const (
 
 const fileListWidth = 30
 
+// hScrollStep is the horizontal scroll distance per key/wheel event.
+const hScrollStep = 8
+
 type Model struct {
 	diff       *git.Diff
 	fileList   fileListModel
@@ -274,27 +277,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "right", "l":
 			if m.fileReviewMode {
+				m.diffView.scrollRight(hScrollStep)
 				return m, nil
 			}
 			if m.focus == focusDiffView {
-				m.fullscreen = !m.fullscreen
-				m.updateLayout()
+				m.diffView.scrollRight(hScrollStep)
 			} else {
 				m.focus = focusDiffView
 			}
 			return m, nil
 
-		case "left", "h", "f", "esc":
+		case "left", "h":
+			if m.fileReviewMode {
+				m.diffView.scrollLeft(hScrollStep)
+				return m, nil
+			}
+			if m.focus == focusDiffView && m.diffView.hOffset > 0 {
+				m.diffView.scrollLeft(hScrollStep)
+				return m, nil
+			}
+			if m.fullscreen {
+				m.fullscreen = false
+				m.updateLayout()
+			}
+			m.focus = focusFileList
+			return m, nil
+
+		case "f", "esc":
 			if m.fileReviewMode {
 				return m, nil
 			}
 			switch msg.String() {
-			case "left", "h":
-				if m.fullscreen {
-					m.fullscreen = false
-					m.updateLayout()
-				}
-				m.focus = focusFileList
 			case "f":
 				m.fullscreen = !m.fullscreen
 				if m.fullscreen {
@@ -434,6 +447,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m.fileList.moveDown()
 				m.syncSelectedFile()
+			}
+		case tea.MouseButtonWheelLeft:
+			if m.mouseFocusDiff(msg) {
+				m.diffView.scrollLeft(hScrollStep)
+			}
+		case tea.MouseButtonWheelRight:
+			if m.mouseFocusDiff(msg) {
+				m.diffView.scrollRight(hScrollStep)
 			}
 		case tea.MouseButtonLeft:
 			if msg.Action != tea.MouseActionPress {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -151,15 +152,17 @@ func TestModelLeftKey_ExitsFullscreen(t *testing.T) {
 	assert.Equal(t, focusFileList, m.focus)
 }
 
-func TestModelRightKey_WhenAlreadyFocused_TogglesFullscreen(t *testing.T) {
+func TestModelRightKey_WhenAlreadyFocused_DoesNotToggleFullscreen(t *testing.T) {
 	m := makeModel("a.go")
 	m = sendKey(m, "l") // focus diff
-	assert.Equal(t, focusDiffView, m.focus)
-	assert.False(t, m.fullscreen)
-	m = sendKey(m, "l") // right again → fullscreen
-	assert.True(t, m.fullscreen)
-	m = sendKey(m, "l") // right again → exit fullscreen
-	assert.False(t, m.fullscreen)
+	require.Equal(t, focusDiffView, m.focus)
+	require.False(t, m.fullscreen)
+	m = sendKey(m, "l") // right again → must NOT toggle fullscreen
+	assert.False(t, m.fullscreen, "right arrow must not toggle fullscreen")
+	m = sendKey(m, "f") // enter fullscreen explicitly
+	require.True(t, m.fullscreen)
+	m = sendKey(m, "l") // right again → must NOT exit fullscreen
+	assert.True(t, m.fullscreen, "right arrow must not exit fullscreen")
 }
 
 func TestModelRightKey_WhenFileListFocused_FocusesDiff(t *testing.T) {
@@ -168,6 +171,65 @@ func TestModelRightKey_WhenFileListFocused_FocusesDiff(t *testing.T) {
 	m = sendKey(m, "l")
 	assert.Equal(t, focusDiffView, m.focus)
 	assert.False(t, m.fullscreen)
+}
+
+func TestModelRightKey_WhenDiffFocused_ScrollsRight(t *testing.T) {
+	m := makeModelWithDiff("foo.go", []git.Line{
+		{Type: git.LineAdded, Content: strings.Repeat("A", 500), NewNum: 1},
+	})
+	m = sendKey(m, "l") // focus diff
+	require.Equal(t, focusDiffView, m.focus)
+	require.Equal(t, 0, m.diffView.hOffset)
+	m = sendKey(m, "l") // right again → scroll right
+	assert.Greater(t, m.diffView.hOffset, 0, "right arrow should scroll right")
+}
+
+func TestModelLeftKey_WhenScrolledRight_ScrollsLeft(t *testing.T) {
+	m := makeModelWithDiff("foo.go", []git.Line{
+		{Type: git.LineAdded, Content: strings.Repeat("A", 500), NewNum: 1},
+	})
+	m = sendKey(m, "l")
+	m = sendKey(m, "l")
+	m = sendKey(m, "l")
+	require.Greater(t, m.diffView.hOffset, 0)
+	prev := m.diffView.hOffset
+	m = sendKey(m, "h") // left while scrolled right → scroll left, not focus change
+	assert.Less(t, m.diffView.hOffset, prev)
+	assert.Equal(t, focusDiffView, m.focus, "left must not change focus while scrolled")
+}
+
+func TestModelLeftKey_AtZeroScroll_FocusesFileList(t *testing.T) {
+	m := makeModelWithDiff("foo.go", []git.Line{
+		{Type: git.LineAdded, Content: "short", NewNum: 1},
+	})
+	m = sendKey(m, "l")
+	require.Equal(t, focusDiffView, m.focus)
+	require.Equal(t, 0, m.diffView.hOffset)
+	m = sendKey(m, "h")
+	assert.Equal(t, focusFileList, m.focus)
+}
+
+func TestModelMouseWheelRight_ScrollsDiffRight(t *testing.T) {
+	m := makeModelWithDiff("foo.go", []git.Line{
+		{Type: git.LineAdded, Content: strings.Repeat("A", 500), NewNum: 1},
+	})
+	m = sendKey(m, "l")
+	require.Equal(t, 0, m.diffView.hOffset)
+	// Click inside the diff pane (x past file list width + gap).
+	updated, _ := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelRight, X: 50, Y: 5})
+	m = updated.(Model)
+	assert.Greater(t, m.diffView.hOffset, 0)
+}
+
+func TestModelMouseWheelLeft_ScrollsDiffLeft(t *testing.T) {
+	m := makeModelWithDiff("foo.go", []git.Line{
+		{Type: git.LineAdded, Content: strings.Repeat("A", 500), NewNum: 1},
+	})
+	m = sendKey(m, "l")
+	m.diffView.hOffset = 20
+	updated, _ := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelLeft, X: 50, Y: 5})
+	m = updated.(Model)
+	assert.Less(t, m.diffView.hOffset, 20)
 }
 
 func TestModelHelpDismissedByAnyKey(t *testing.T) {


### PR DESCRIPTION
Closes #121.

## Summary
- Right arrow (or `l`) in a focused diff view now scrolls right instead of toggling fullscreen. Pressing it a second time no longer exits fullscreen.
- Left arrow (or `h`) scrolls left when `hOffset > 0`; at column 0 it falls back to focusing the file list (and exits fullscreen).
- Mouse wheel left/right horizontally scrolls the diff when the cursor is over the diff pane.
- `f` remains the fullscreen toggle.
- Horizontal offset resets when switching files.

## Implementation
- `diffView.hOffset` + `scrollLeft`/`scrollRight`/`maxHScroll` methods, applied in the render loop via `ansi.TruncateLeft`.
- Model routes `right`/`left`/`h`/`l` and `MouseButtonWheel{Left,Right}` to the new scroll methods; `f`/`esc` are now their own case in the key switch.
- `hScrollStep = 8` cols per step.

## Test plan
- [x] `make` (lint + tests) — all green
- [x] Unit tests: scroll clamp, setFile reset, arrow key routing, mouse wheel
- [ ] Manual: scroll a wide diff line with arrows and mouse wheel in both windowed and fullscreen modes
- [ ] Manual: verify left arrow at column 0 still exits fullscreen / focuses file list
- [ ] Manual: verify `f` still toggles fullscreen

Also opened #163 for the soft-wrap follow-up (Alt+Z convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Horizontal scrolling in the diff view using arrow keys (left/right or h/l) and mouse wheel scrolling.

* **Changed**
  * Right arrow now scrolls the diff view right instead of toggling fullscreen.
  * Left arrow scrolls the diff view left; focuses the file list when already at the scroll start.
  * Fullscreen toggle moved to the f key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->