### PR TITLE
Fire immediate poll on terminal refocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Right arrow no longer toggles fullscreen — it scrolls right when the diff is focused. Use `f` to toggle fullscreen. Left arrow scrolls left first, then falls back to focusing the file list when already at column 0 (#121)
 
+### Fixed
+
+- Refresh fires immediately when the terminal regains focus instead of waiting a full poll interval, so switching back to revise shows current state right away (#144)
+
 ## [0.3.0] - 2026-04-15
 
 ### Added

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -600,8 +600,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.FocusMsg:
 		m.focused = true
-		// Resume polling now that we have focus again.
-		return m, tea.Tick(pollInterval, func(time.Time) tea.Msg { return pollTickMsg{} })
+		// Poll immediately on refocus so users see fresh state right away
+		// rather than waiting a full pollInterval (see #144).
+		return m, func() tea.Msg { return pollTickMsg{} }
 
 	case tea.BlurMsg:
 		m.focused = false

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1557,6 +1557,27 @@ func TestFocus_ResumesPolling(t *testing.T) {
 	assert.NotNil(t, cmd, "focus should schedule a poll tick")
 }
 
+// Regression for #144: on refocus, the poll must fire immediately rather
+// than waiting a full pollInterval, so users see fresh state right away
+// when they switch back to revise.
+func TestFocus_TriggersImmediatePoll(t *testing.T) {
+	m := makeModel("a.go")
+	m.focused = false
+
+	_, cmd := m.Update(tea.FocusMsg{})
+	require.NotNil(t, cmd)
+
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+	select {
+	case msg := <-done:
+		_, ok := msg.(pollTickMsg)
+		assert.True(t, ok, "focus cmd should return pollTickMsg immediately, got %T", msg)
+	case <-time.After(1 * time.Second):
+		t.Fatal("focus cmd did not complete within 1s — still gated by pollInterval")
+	}
+}
+
 func TestPollResult_SkipsNextTickWhenUnfocused(t *testing.T) {
 	m := makeModel("a.go")
 	m.polling = true


### PR DESCRIPTION
## Summary

- On `tea.FocusMsg`, send a `pollTickMsg` immediately instead of scheduling it a full `pollInterval` (30s) out
- The existing in-flight guard (`m.polling`) and post-poll scheduling loop are unchanged, so poll frequency and I/O contention protections from #130 stay intact
- Adds `TestFocus_TriggersImmediatePoll` — fails on old behavior because the returned cmd was a 30s `tea.Tick`

## Test plan

- [x] `make` passes (lint + test)
- [x] `make install` succeeds
- [ ] Manual: edit a file in another shell, switch to revise in tmux, confirm the file list refreshes within ~1 second

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)