### PR TITLE
Auto-promote to Branch mode when fresh branch diverges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- The `Branch` label in the mode slider is always shown — greyed out (faint italic) when on the default branch where Branch mode isn't available — so its position stays stable and users can see the mode exists (#148)
+- The `Branch` label in the mode slider is always shown — greyed out (faint + strikethrough) when on the default branch where Branch mode isn't available — so its position stays stable and users can see the mode exists (#148)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Right arrow no longer toggles fullscreen — it scrolls right when the diff is focused. Use `f` to toggle fullscreen. Left arrow scrolls left first, then falls back to focusing the file list when already at column 0 (#121)
 
+### Changed
+
+- The `Branch` label in the mode slider is always shown — greyed out (faint italic) when on the default branch where Branch mode isn't available — so its position stays stable and users can see the mode exists (#148)
+
 ### Fixed
 
 - When a fresh branch diverges from default while revise is running (e.g. after a commit), the mode auto-promotes from Staged to Branch so new commits become visible, unless the user has explicitly picked a mode (#148)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Right arrow no longer toggles fullscreen — it scrolls right when the diff is focused. Use `f` to toggle fullscreen. Left arrow scrolls left first, then falls back to focusing the file list when already at column 0 (#121)
 
+### Fixed
+
+- When a fresh branch diverges from default while revise is running (e.g. after a commit), the mode auto-promotes from Staged to Branch so new commits become visible, unless the user has explicitly picked a mode (#148)
+
 ## [0.3.0] - 2026-04-15
 
 ### Added

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -463,7 +463,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// Check for status bar slider click
 			if msg.Y == m.height-1 {
-				if mode := m.sliderModeAt(msg.X); mode >= 0 && mode != m.mode {
+				if mode := m.sliderModeAt(msg.X); mode >= 0 && mode != m.mode && m.modeAvailable(mode) {
 					m.mode = mode
 					m.modeExplicitlySet = true
 					return m, m.loadDiff()
@@ -1157,7 +1157,9 @@ func (m Model) mouseFocusDiff(msg tea.MouseMsg) bool {
 }
 
 // sliderModeAt returns the DiffMode at the given X position in the slider,
-// or -1 if the click is outside the slider labels.
+// or -1 if the click is outside the slider labels. Branch is always included
+// in the layout, even when disabled — callers should check availableModes()
+// before acting on the result.
 func (m Model) sliderModeAt(x int) DiffMode {
 	type region struct {
 		start, end int
@@ -1166,18 +1168,21 @@ func (m Model) sliderModeAt(x int) DiffMode {
 	var regions []region
 	pos := 0
 
-	if !m.onDefaultBranch {
-		label := "Branch"
-		regions = append(regions, region{pos, pos + len(label) - 1, ModeBranch})
-		pos += len(label) + 1 // +1 for "·" separator
+	labels := []struct {
+		name string
+		mode DiffMode
+	}{
+		{"Branch", ModeBranch},
+		{"Staged", ModeStaged},
+		{"Unstaged", ModeUnstaged},
 	}
-
-	label := "Staged"
-	regions = append(regions, region{pos, pos + len(label) - 1, ModeStaged})
-	pos += len(label) + 1
-
-	label = "Unstaged"
-	regions = append(regions, region{pos, pos + len(label) - 1, ModeUnstaged})
+	for i, l := range labels {
+		regions = append(regions, region{pos, pos + len(l.name) - 1, l.mode})
+		pos += len(l.name)
+		if i < len(labels)-1 {
+			pos++ // separator
+		}
+	}
 
 	for _, r := range regions {
 		if x >= r.start && x <= r.end {
@@ -1194,6 +1199,17 @@ func (m Model) availableModes() []DiffMode {
 		return []DiffMode{ModeStaged, ModeStagedOnly, ModeUnstaged}
 	}
 	return []DiffMode{ModeBranch, ModeStaged, ModeStagedOnly, ModeUnstaged}
+}
+
+// modeAvailable reports whether the given mode is selectable in the current
+// branch state.
+func (m Model) modeAvailable(mode DiffMode) bool {
+	for _, am := range m.availableModes() {
+		if am == mode {
+			return true
+		}
+	}
+	return false
 }
 
 // cycleMode advances the mode by direction (+1 or -1), wrapping around.
@@ -1262,41 +1278,43 @@ func (m *Model) prevFile() {
 }
 
 func (m Model) renderModeSlider() string {
-	render := func(name string, active bool) string {
-		if active {
+	render := func(name string, active, disabled bool) string {
+		switch {
+		case disabled:
+			return modeDisabledStyle.Render(name)
+		case active:
 			return modeActiveStyle.Render(name)
+		default:
+			return modeInactiveStyle.Render(name)
 		}
-		return modeInactiveStyle.Render(name)
 	}
 
 	type label struct {
-		name   string
-		active bool
+		name     string
+		active   bool
+		disabled bool
 	}
-	var labels []label
 
 	// Cumulative: broadest mode (ModeBranch) lights all,
 	// narrower modes drop components from the left.
 	// ModeStagedOnly lights only Staged; ModeUnstaged lights only Unstaged.
-	if !m.onDefaultBranch {
-		labels = append(labels, label{"Branch", m.mode == ModeBranch})
+	// Branch is always shown — greyed out on the default branch.
+	labels := []label{
+		{"Branch", m.mode == ModeBranch, m.onDefaultBranch},
+		{"Staged", m.mode == ModeBranch || m.mode == ModeStaged || m.mode == ModeStagedOnly, false},
+		{"Unstaged", m.mode == ModeBranch || m.mode == ModeStaged || m.mode == ModeUnstaged, false},
 	}
-	labels = append(labels,
-		label{"Staged", m.mode == ModeBranch || m.mode == ModeStaged || m.mode == ModeStagedOnly},
-		label{"Unstaged", m.mode == ModeBranch || m.mode == ModeStaged || m.mode == ModeUnstaged},
-	)
 
 	var result string
 	for i, l := range labels {
 		if i > 0 {
-			// Use + between two active labels, space otherwise
 			if labels[i-1].active && l.active {
 				result += modeActiveStyle.Render("+")
 			} else {
 				result += modeInactiveStyle.Render(" ")
 			}
 		}
-		result += render(l.name, l.active)
+		result += render(l.name, l.active, l.disabled)
 	}
 
 	return result

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -93,10 +93,11 @@ type Model struct {
 	height     int
 	ready      bool
 
-	mode            DiffMode
-	onDefaultBranch bool
-	contextLines    int
-	hideWhitespace  bool
+	mode              DiffMode
+	modeExplicitlySet bool // true once the user has manually picked a mode (#148)
+	onDefaultBranch   bool
+	contextLines      int
+	hideWhitespace    bool
 
 	comments           comments
 	marks              marks
@@ -464,6 +465,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.Y == m.height-1 {
 				if mode := m.sliderModeAt(msg.X); mode >= 0 && mode != m.mode {
 					m.mode = mode
+					m.modeExplicitlySet = true
 					return m, m.loadDiff()
 				}
 				return m, nil
@@ -531,7 +533,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Update default-branch status so Branch mode becomes
 		// available (or unavailable) dynamically.
+		wasOnDefaultBranch := m.onDefaultBranch
 		m.onDefaultBranch = msg.onDefaultBranch
+		// When the branch diverges from default while revise is running
+		// (e.g. user committed on a fresh branch), promote mode to
+		// ModeBranch so the new commits are visible — but only if the
+		// user hasn't explicitly picked a different mode (see #148).
+		if wasOnDefaultBranch && !m.onDefaultBranch && !m.modeExplicitlySet {
+			m.mode = ModeBranch
+		}
 		// If the current mode is no longer valid, clamp it.
 		modes := m.availableModes()
 		modeValid := false
@@ -1198,6 +1208,7 @@ func (m *Model) cycleMode(direction int) {
 	}
 	nextIdx := (currentIdx + direction + len(modes)) % len(modes)
 	m.mode = modes[nextIdx]
+	m.modeExplicitlySet = true
 }
 
 // loadDiff returns a command that fetches the diff for the current mode.

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -492,21 +492,45 @@ func TestDiffRefresh_UpdatesOnDefaultBranch(t *testing.T) {
 	assert.Equal(t, []DiffMode{ModeBranch, ModeStaged, ModeStagedOnly, ModeUnstaged}, m.availableModes())
 }
 
-func TestDiffRefresh_SwitchesToFeatureBranch_KeepsCurrentMode(t *testing.T) {
-	// Start on default branch in ModeStaged
+// Regression for #148: when the branch diverges from default while revise is
+// running (e.g. user committed on a fresh branch), promote mode to ModeBranch
+// so the new committed changes become visible — unless the user has explicitly
+// chosen a different mode.
+func TestDiffRefresh_SwitchesToFeatureBranch_PromotesToBranchMode(t *testing.T) {
 	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	m = updated.(Model)
 	require.Equal(t, ModeStaged, m.mode)
+	require.False(t, m.modeExplicitlySet)
 
-	// Switch to feature branch — mode should stay ModeStaged (still valid)
 	updated, _ = m.Update(diffLoadedMsg{
 		diff:            &git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}},
 		onDefaultBranch: false,
 	})
 	m = updated.(Model)
 
-	assert.Equal(t, ModeStaged, m.mode, "should keep current mode when it's still valid")
+	assert.Equal(t, ModeBranch, m.mode, "should promote to ModeBranch when branch diverges and mode is the default")
+}
+
+// If the user explicitly picked a mode on the default branch, respect that
+// choice across the transition — don't auto-promote to ModeBranch.
+func TestDiffRefresh_SwitchesToFeatureBranch_PreservesExplicitMode(t *testing.T) {
+	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+
+	// Simulate Tab/Shift+Tab — cycleMode marks mode as explicit.
+	m.cycleMode(+1)
+	require.Equal(t, ModeStagedOnly, m.mode)
+	require.True(t, m.modeExplicitlySet)
+
+	updated, _ = m.Update(diffLoadedMsg{
+		diff:            &git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}},
+		onDefaultBranch: false,
+	})
+	m = updated.(Model)
+
+	assert.Equal(t, ModeStagedOnly, m.mode, "should preserve explicitly-chosen mode across branch divergence")
 }
 
 func TestDiffRefresh_SwitchesToDefaultBranch_ClampsMode(t *testing.T) {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -560,13 +560,14 @@ func TestModeSlider_FeatureBranch_BranchMode_AllLit(t *testing.T) {
 	assert.Contains(t, slider, "Unstaged")
 }
 
-func TestModeSlider_DefaultBranch_OmitsBranch(t *testing.T) {
+func TestModeSlider_DefaultBranch_ShowsBranchDisabled(t *testing.T) {
 	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	m = updated.(Model)
 
 	slider := m.renderModeSlider()
-	assert.NotContains(t, slider, "Branch")
+	// Branch is always shown — greyed out / disabled when unavailable.
+	assert.Contains(t, ansi.Strip(slider), "Branch")
 	assert.Contains(t, slider, "Staged")
 	assert.Contains(t, slider, "Unstaged")
 }
@@ -637,18 +638,37 @@ func TestSliderModeAt_DefaultBranch_ClickStaged(t *testing.T) {
 	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	m = updated.(Model)
-	// "Staged·Unstaged" — "Staged" at positions 0-5
-	assert.Equal(t, ModeStaged, m.sliderModeAt(0))
-	assert.Equal(t, ModeStaged, m.sliderModeAt(5))
+	// "Branch Staged Unstaged" — "Staged" at positions 7-12 (Branch is shown but disabled)
+	assert.Equal(t, ModeStaged, m.sliderModeAt(7))
+	assert.Equal(t, ModeStaged, m.sliderModeAt(12))
 }
 
 func TestSliderModeAt_DefaultBranch_ClickUnstaged(t *testing.T) {
 	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	m = updated.(Model)
-	// "Staged·Unstaged" — "Unstaged" at positions 7-14
-	assert.Equal(t, ModeUnstaged, m.sliderModeAt(7))
+	// "Branch Staged Unstaged" — "Unstaged" at positions 14-21
 	assert.Equal(t, ModeUnstaged, m.sliderModeAt(14))
+	assert.Equal(t, ModeUnstaged, m.sliderModeAt(21))
+}
+
+// Clicking the Branch label while on the default branch (where it's disabled)
+// should be a no-op — mode unchanged, no diff reload.
+func TestMouseClickSlider_DefaultBranch_BranchDisabled_NoOp(t *testing.T) {
+	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	require.Equal(t, ModeStaged, m.mode)
+
+	mouseMsg := tea.MouseMsg{
+		X:      0, // "Branch" label
+		Y:      m.height - 1,
+		Button: tea.MouseButtonLeft,
+	}
+	updated, cmd := m.Update(mouseMsg)
+	m = updated.(Model)
+	assert.Equal(t, ModeStaged, m.mode, "click on disabled Branch should not change mode")
+	assert.Nil(t, cmd, "click on disabled Branch should not reload")
 }
 
 func TestSliderModeAt_OutsideLabels(t *testing.T) {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -94,6 +94,7 @@ var (
 	// Mode slider styles
 	modeActiveStyle   lipgloss.Style
 	modeInactiveStyle lipgloss.Style
+	modeDisabledStyle lipgloss.Style // mode not available on current branch
 
 	// Status bar
 	statusBarStyle lipgloss.Style
@@ -186,6 +187,7 @@ func applyTheme(p themeColors) {
 
 	modeActiveStyle = lipgloss.NewStyle().Foreground(p.cyan).Bold(true)
 	modeInactiveStyle = lipgloss.NewStyle().Foreground(p.dim)
+	modeDisabledStyle = lipgloss.NewStyle().Foreground(p.dim).Faint(true).Italic(true)
 
 	statusBarStyle = lipgloss.NewStyle().Foreground(p.dim)
 
@@ -244,6 +246,7 @@ func applyNoColor() {
 	commentInputStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
 	modeActiveStyle = lipgloss.NewStyle().Bold(true)
 	modeInactiveStyle = lipgloss.NewStyle()
+	modeDisabledStyle = lipgloss.NewStyle().Faint(true).Italic(true)
 	statusBarStyle = lipgloss.NewStyle()
 	helpKeyStyle = lipgloss.NewStyle().Bold(true)
 	helpTextStyle = lipgloss.NewStyle()

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -187,7 +187,7 @@ func applyTheme(p themeColors) {
 
 	modeActiveStyle = lipgloss.NewStyle().Foreground(p.cyan).Bold(true)
 	modeInactiveStyle = lipgloss.NewStyle().Foreground(p.dim)
-	modeDisabledStyle = lipgloss.NewStyle().Foreground(p.dim).Faint(true).Italic(true)
+	modeDisabledStyle = lipgloss.NewStyle().Foreground(p.dim).Faint(true).Strikethrough(true)
 
 	statusBarStyle = lipgloss.NewStyle().Foreground(p.dim)
 
@@ -246,7 +246,7 @@ func applyNoColor() {
 	commentInputStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
 	modeActiveStyle = lipgloss.NewStyle().Bold(true)
 	modeInactiveStyle = lipgloss.NewStyle()
-	modeDisabledStyle = lipgloss.NewStyle().Faint(true).Italic(true)
+	modeDisabledStyle = lipgloss.NewStyle().Faint(true).Strikethrough(true)
 	statusBarStyle = lipgloss.NewStyle()
 	helpKeyStyle = lipgloss.NewStyle().Bold(true)
 	helpTextStyle = lipgloss.NewStyle()


### PR DESCRIPTION
## Summary

Two related UX improvements around Branch mode on the default branch.

**Auto-promote mode on branch divergence (#148):**
- Track whether mode was explicitly chosen via Tab/Shift+Tab (`cycleMode`) or slider click, via a new `modeExplicitlySet` flag on `Model`
- In the `diffLoadedMsg` handler, on the `onDefaultBranch` true→false transition, promote mode to `ModeBranch` when the user hasn't explicitly picked one

**Always show Branch label in the slider:**
- Render `Branch` at a fixed position; grey out (dim + faint + italic) when on the default branch
- Slider clicks filter through `availableModes()` via a new `modeAvailable` helper so greyed-out Branch is a no-op
- Keeps the slider layout stable and makes the mode's existence discoverable

## Considered while working on this

- **#95 (more compare options)** — orthogonal to this fix. #95 wants alternate comparison *bases* (previous commit, arbitrary base/sha), whereas this is about default-mode selection on the existing base. The `modeExplicitlySet` flag won't interfere with a future compare-base feature.

## Test plan

- [x] `make` passes (lint + test)
- [x] `make install` succeeds
- [ ] Manual: on `main`, launch revise, confirm "Branch" appears greyed out in the slider
- [ ] Manual: click the greyed-out Branch label — nothing happens
- [ ] Manual: on `main`, launch revise, run `git checkout -b scratch && echo foo >> foo.md && git add . && git commit -m test`; confirm mode flips to Branch, label becomes active, and the commit is visible
- [ ] Manual: on `main`, launch revise, press Tab to land on `ModeStagedOnly`, then commit; confirm mode stays `ModeStagedOnly`

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Revise-mode now automatically promotes from Staged to Branch when branching off the default branch, ensuring new commits are visible
  * User-selected modes are now preserved when switching between branches

* **Style**
  * Mode slider displays Branch label consistently (greyed-out when unavailable) to maintain stable layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->