### PR TITLE
Make mark highlight noticeable; add comment-line stripe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - When a fresh branch diverges from default while revise is running (e.g. after a commit), the mode auto-promotes from Staged to Branch so new commits become visible, unless the user has explicitly picked a mode (#148)
 - Marked lines are now visibly distinct: brighter mark backgrounds and a colored `▌` bookmark stripe in the leading prefix column. Daltonized themes use a purple mark color so the highlight no longer collides with the blue "added" background (#173)
+- Commented lines also get a yellow `▌` bookmark stripe in the leading prefix column, matching the mark-line treatment (#173)
 
 ## [0.3.0] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - When a fresh branch diverges from default while revise is running (e.g. after a commit), the mode auto-promotes from Staged to Branch so new commits become visible, unless the user has explicitly picked a mode (#148)
+- Marked lines are now visibly distinct: brighter mark backgrounds and a colored `▌` bookmark stripe in the leading prefix column. Daltonized themes use a purple mark color so the highlight no longer collides with the blue "added" background (#173)
 
 ## [0.3.0] - 2026-04-15
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -508,10 +508,15 @@ func hunkContext(header string) string {
 }
 
 // linePrefix returns the 1-character indicator for a display line — cursor
-// (when focused), else a mark stripe for marked lines, else a blank.
+// (when focused), else a bookmark stripe for commented or marked lines, else
+// a blank. Comments win over marks because they carry richer information;
+// the mark's colored gutter background is still visible.
 func (m diffViewModel) linePrefix(absIdx int, focused bool) string {
 	if focused && m.file != nil && absIdx == m.cursor {
 		return cursorStyle.Render("▶")
+	}
+	if m.lineCommented(absIdx) {
+		return commentPrefixStyle.Render("▌")
 	}
 	if m.lineMarked(absIdx) {
 		return markPrefixStyle.Render("▌")
@@ -522,14 +527,35 @@ func (m diffViewModel) linePrefix(absIdx int, focused bool) string {
 // lineMarked reports whether the given display line corresponds to a marked
 // source line.
 func (m diffViewModel) lineMarked(absIdx int) bool {
-	if m.file == nil || absIdx < 0 || absIdx >= len(m.lineRefs) {
-		return false
-	}
-	ref := m.lineRefs[absIdx]
-	if ref == nil || ref.isCommentDisplay {
+	ref := m.codeLineRef(absIdx)
+	if ref == nil {
 		return false
 	}
 	return m.marks[ref.commentKey(m.file.Path)]
+}
+
+// lineCommented reports whether the given display line corresponds to a
+// source line that has a saved comment.
+func (m diffViewModel) lineCommented(absIdx int) bool {
+	ref := m.codeLineRef(absIdx)
+	if ref == nil {
+		return false
+	}
+	_, ok := m.comments[ref.commentKey(m.file.Path)]
+	return ok
+}
+
+// codeLineRef returns the lineRef for a real code line at absIdx, or nil
+// if the index is out of range, points at a non-code row, or no file is open.
+func (m diffViewModel) codeLineRef(absIdx int) *lineRef {
+	if m.file == nil || absIdx < 0 || absIdx >= len(m.lineRefs) {
+		return nil
+	}
+	ref := m.lineRefs[absIdx]
+	if ref == nil || ref.isCommentDisplay {
+		return nil
+	}
+	return ref
 }
 
 // currentHunkIndex returns the index of the hunk containing the cursor line,

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -163,7 +163,7 @@ func (m *diffViewModel) rebuildLinesPreservingCursor() {
 
 // isNavigable reports whether the line at idx can receive the cursor.
 // Only code lines (non-nil, non-comment-display) are navigable.
-func (m *diffViewModel) isNavigable(idx int) bool {
+func (m diffViewModel) isNavigable(idx int) bool {
 	if idx < 0 || idx >= len(m.lineRefs) {
 		return false
 	}
@@ -548,14 +548,10 @@ func (m diffViewModel) lineCommented(absIdx int) bool {
 // codeLineRef returns the lineRef for a real code line at absIdx, or nil
 // if the index is out of range, points at a non-code row, or no file is open.
 func (m diffViewModel) codeLineRef(absIdx int) *lineRef {
-	if m.file == nil || absIdx < 0 || absIdx >= len(m.lineRefs) {
+	if m.file == nil || !m.isNavigable(absIdx) {
 		return nil
 	}
-	ref := m.lineRefs[absIdx]
-	if ref == nil || ref.isCommentDisplay {
-		return nil
-	}
-	return ref
+	return m.lineRefs[absIdx]
 }
 
 // currentHunkIndex returns the index of the hunk containing the cursor line,

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -507,13 +507,29 @@ func hunkContext(header string) string {
 	return strings.TrimSpace(parts[2])
 }
 
-// linePrefix returns the 1-character cursor indicator for a display line.
-// The cursor is only shown when the diff pane is focused.
+// linePrefix returns the 1-character indicator for a display line — cursor
+// (when focused), else a mark stripe for marked lines, else a blank.
 func (m diffViewModel) linePrefix(absIdx int, focused bool) string {
 	if focused && m.file != nil && absIdx == m.cursor {
 		return cursorStyle.Render("▶")
 	}
+	if m.lineMarked(absIdx) {
+		return markPrefixStyle.Render("▌")
+	}
 	return " "
+}
+
+// lineMarked reports whether the given display line corresponds to a marked
+// source line.
+func (m diffViewModel) lineMarked(absIdx int) bool {
+	if m.file == nil || absIdx < 0 || absIdx >= len(m.lineRefs) {
+		return false
+	}
+	ref := m.lineRefs[absIdx]
+	if ref == nil || ref.isCommentDisplay {
+		return false
+	}
+	return m.marks[ref.commentKey(m.file.Path)]
 }
 
 // currentHunkIndex returns the index of the hunk containing the cursor line,

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -298,6 +298,16 @@ func TestLinePrefix_MarkedLineUnderCursorShowsCursor(t *testing.T) {
 	assert.Contains(t, m.linePrefix(0, true), "▶")
 }
 
+func TestLinePrefix_CommentedLine(t *testing.T) {
+	m := newDiffViewModel()
+	m.file = &git.FileDiff{Path: "foo.go"}
+	m.lineRefs = []*lineRef{{newNum: 10, lineType: git.LineAdded}}
+	m.comments = comments{commentKey{file: "foo.go", lineNum: 10}: "nit"}
+	m.cursor = 99
+	// Commented lines render a yellow left half-block as a bookmark stripe.
+	assert.Contains(t, m.linePrefix(0, true), "▌")
+}
+
 func TestLineRef_CommentKey_Added(t *testing.T) {
 	r := lineRef{newNum: 10, oldNum: 0, lineType: git.LineAdded}
 	key := r.commentKey("foo.go")

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -285,7 +285,7 @@ func TestLinePrefix_MarkedLine(t *testing.T) {
 	m.cursor = 99 // cursor not on this line
 	// Marked lines render a heavy left half-block in the prefix column,
 	// acting as a bookmark stripe at the leftmost edge.
-	assert.Contains(t, m.linePrefix(0, true), "▌")
+	assert.Equal(t, markPrefixStyle.Render("▌"), m.linePrefix(0, true))
 }
 
 func TestLinePrefix_MarkedLineUnderCursorShowsCursor(t *testing.T) {
@@ -295,7 +295,7 @@ func TestLinePrefix_MarkedLineUnderCursorShowsCursor(t *testing.T) {
 	m.marks = marks{commentKey{file: "foo.go", lineNum: 10, isOld: false}: true}
 	m.cursor = 0
 	// Cursor takes priority over the mark indicator.
-	assert.Contains(t, m.linePrefix(0, true), "▶")
+	assert.Equal(t, cursorStyle.Render("▶"), m.linePrefix(0, true))
 }
 
 func TestLinePrefix_CommentedLine(t *testing.T) {
@@ -305,7 +305,7 @@ func TestLinePrefix_CommentedLine(t *testing.T) {
 	m.comments = comments{commentKey{file: "foo.go", lineNum: 10}: "nit"}
 	m.cursor = 99
 	// Commented lines render a yellow left half-block as a bookmark stripe.
-	assert.Contains(t, m.linePrefix(0, true), "▌")
+	assert.Equal(t, commentPrefixStyle.Render("▌"), m.linePrefix(0, true))
 }
 
 func TestLinePrefix_CommentedAndMarked_CommentWins(t *testing.T) {
@@ -316,9 +316,10 @@ func TestLinePrefix_CommentedAndMarked_CommentWins(t *testing.T) {
 	m.marks = marks{key: true}
 	m.comments = comments{key: "nit"}
 	m.cursor = 99
-	got := m.linePrefix(0, true)
-	assert.Equal(t, commentPrefixStyle.Render("▌"), got)
-	assert.NotEqual(t, markPrefixStyle.Render("▌"), got)
+	// Comment style wins; equality alone proves precedence in colored mode.
+	// (In NO_COLOR mode comment and mark styles render identically, so a
+	// NotEqual check would be incorrect.)
+	assert.Equal(t, commentPrefixStyle.Render("▌"), m.linePrefix(0, true))
 }
 
 func TestLineRef_CommentKey_Added(t *testing.T) {

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -277,6 +277,27 @@ func TestLinePrefix_WithFileSelected_NotFocused(t *testing.T) {
 	assert.Equal(t, " ", m.linePrefix(2, false)) // cursor hidden when not focused
 }
 
+func TestLinePrefix_MarkedLine(t *testing.T) {
+	m := newDiffViewModel()
+	m.file = &git.FileDiff{Path: "foo.go"}
+	m.lineRefs = []*lineRef{{newNum: 10, lineType: git.LineAdded}}
+	m.marks = marks{commentKey{file: "foo.go", lineNum: 10, isOld: false}: true}
+	m.cursor = 99 // cursor not on this line
+	// Marked lines render a heavy left half-block in the prefix column,
+	// acting as a bookmark stripe at the leftmost edge.
+	assert.Contains(t, m.linePrefix(0, true), "▌")
+}
+
+func TestLinePrefix_MarkedLineUnderCursorShowsCursor(t *testing.T) {
+	m := newDiffViewModel()
+	m.file = &git.FileDiff{Path: "foo.go"}
+	m.lineRefs = []*lineRef{{newNum: 10, lineType: git.LineAdded}}
+	m.marks = marks{commentKey{file: "foo.go", lineNum: 10, isOld: false}: true}
+	m.cursor = 0
+	// Cursor takes priority over the mark indicator.
+	assert.Contains(t, m.linePrefix(0, true), "▶")
+}
+
 func TestLineRef_CommentKey_Added(t *testing.T) {
 	r := lineRef{newNum: 10, oldNum: 0, lineType: git.LineAdded}
 	key := r.commentKey("foo.go")

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -308,6 +308,19 @@ func TestLinePrefix_CommentedLine(t *testing.T) {
 	assert.Contains(t, m.linePrefix(0, true), "▌")
 }
 
+func TestLinePrefix_CommentedAndMarked_CommentWins(t *testing.T) {
+	m := newDiffViewModel()
+	m.file = &git.FileDiff{Path: "foo.go"}
+	m.lineRefs = []*lineRef{{newNum: 10, lineType: git.LineAdded}}
+	key := commentKey{file: "foo.go", lineNum: 10, isOld: false}
+	m.marks = marks{key: true}
+	m.comments = comments{key: "nit"}
+	m.cursor = 99
+	got := m.linePrefix(0, true)
+	assert.Equal(t, commentPrefixStyle.Render("▌"), got)
+	assert.NotEqual(t, markPrefixStyle.Render("▌"), got)
+}
+
 func TestLineRef_CommentKey_Added(t *testing.T) {
 	r := lineRef{newNum: 10, oldNum: 0, lineType: git.LineAdded}
 	key := r.commentKey("foo.go")

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -87,6 +87,7 @@ var (
 	markGutterAdded   lipgloss.Style
 	markGutterRemoved lipgloss.Style
 	markGutterContext lipgloss.Style
+	markPrefixStyle   lipgloss.Style // bookmark stripe in the leading 1-char prefix column
 
 	// Inline comment input box
 	commentInputStyle lipgloss.Style
@@ -179,6 +180,7 @@ func applyTheme(p themeColors) {
 	markGutterAdded = lipgloss.NewStyle().Bold(true).Foreground(p.addedFg).Background(p.markBg).Width(6)
 	markGutterRemoved = lipgloss.NewStyle().Bold(true).Foreground(p.removedFg).Background(p.markBg).Width(6)
 	markGutterContext = lipgloss.NewStyle().Bold(true).Foreground(p.white).Background(p.markBg).Width(6)
+	markPrefixStyle = lipgloss.NewStyle().Bold(true).Foreground(p.markFg)
 
 	commentInputStyle = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -243,6 +245,7 @@ func applyNoColor() {
 	markGutterAdded = lipgloss.NewStyle().Bold(true).Reverse(true).Width(6)
 	markGutterRemoved = lipgloss.NewStyle().Bold(true).Reverse(true).Width(6)
 	markGutterContext = lipgloss.NewStyle().Bold(true).Reverse(true).Width(6)
+	markPrefixStyle = lipgloss.NewStyle().Bold(true)
 	commentInputStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
 	modeActiveStyle = lipgloss.NewStyle().Bold(true)
 	modeInactiveStyle = lipgloss.NewStyle()

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -87,7 +87,8 @@ var (
 	markGutterAdded   lipgloss.Style
 	markGutterRemoved lipgloss.Style
 	markGutterContext lipgloss.Style
-	markPrefixStyle   lipgloss.Style // bookmark stripe in the leading 1-char prefix column
+	markPrefixStyle    lipgloss.Style // bookmark stripe in the leading 1-char prefix column
+	commentPrefixStyle lipgloss.Style // bookmark stripe for commented lines
 
 	// Inline comment input box
 	commentInputStyle lipgloss.Style
@@ -181,6 +182,7 @@ func applyTheme(p themeColors) {
 	markGutterRemoved = lipgloss.NewStyle().Bold(true).Foreground(p.removedFg).Background(p.markBg).Width(6)
 	markGutterContext = lipgloss.NewStyle().Bold(true).Foreground(p.white).Background(p.markBg).Width(6)
 	markPrefixStyle = lipgloss.NewStyle().Bold(true).Foreground(p.markFg)
+	commentPrefixStyle = lipgloss.NewStyle().Bold(true).Foreground(p.yellow)
 
 	commentInputStyle = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -246,6 +248,7 @@ func applyNoColor() {
 	markGutterRemoved = lipgloss.NewStyle().Bold(true).Reverse(true).Width(6)
 	markGutterContext = lipgloss.NewStyle().Bold(true).Reverse(true).Width(6)
 	markPrefixStyle = lipgloss.NewStyle().Bold(true)
+	commentPrefixStyle = lipgloss.NewStyle().Bold(true)
 	commentInputStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
 	modeActiveStyle = lipgloss.NewStyle().Bold(true)
 	modeInactiveStyle = lipgloss.NewStyle()

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -210,6 +210,7 @@ type themeColors struct {
 	gutterRemovedFg color.Color
 
 	markBg color.Color
+	markFg color.Color // foreground for the leading bookmark stripe
 }
 
 // paletteFor returns the color palette for the given theme.
@@ -255,7 +256,8 @@ func autoPalette() themeColors {
 		dimYellow:       lipgloss.Yellow,
 		gutterAddedFg:   lipgloss.Color("28"),
 		gutterRemovedFg: lipgloss.Color("88"),
-		markBg:          lipgloss.Color("#1a1f2e"),
+		markBg:          lipgloss.Color("#2d4a7a"),
+		markFg:          lipgloss.Color("#5b9bd5"),
 	}
 }
 
@@ -264,6 +266,8 @@ func autoDaltonizedPalette() themeColors {
 	p.addedFg = lipgloss.Blue
 	p.addedBg = lipgloss.Color("#1a1f2e")
 	p.gutterAddedFg = lipgloss.Color("27") // ANSI 256: muted blue
+	p.markBg = lipgloss.Color("#5a2d6e") // purple — distinct from blue addedBg
+	p.markFg = lipgloss.Color("#c084fc")
 	return p
 }
 
@@ -281,7 +285,8 @@ func charmtoneDarkPalette() themeColors {
 		dimGreen:  lipgloss.Color("#00A475"), // Pickle
 		dimRed:    lipgloss.Color("#AB2454"), // Pom
 		dimYellow: lipgloss.Color("#858392"), // Squid
-		markBg:    lipgloss.Color("#18463D"), // Gator
+		markBg:    lipgloss.Color("#2d4a7a"), // saturated blue, distinct from green/red diff bgs
+		markFg:    lipgloss.Color("#4FBEFE"), // Sardine
 	}
 }
 
@@ -290,7 +295,8 @@ func charmtoneDarkDaltonizedPalette() themeColors {
 	p.addedFg = lipgloss.Color("#4FBEFE") // Sardine (blue)
 	p.addedBg = lipgloss.Color("#0F2A4A") // deep navy
 	p.dimGreen = lipgloss.Color("#007AB8") // Damson
-	p.markBg = lipgloss.Color("#0F2A4A")
+	p.markBg = lipgloss.Color("#5a2d6e") // purple — distinct from blue addedBg
+	p.markFg = lipgloss.Color("#c084fc")
 	return p
 }
 
@@ -309,6 +315,7 @@ func charmtoneLightPalette() themeColors {
 		dimRed:    lipgloss.Color("#9f1239"),
 		dimYellow: lipgloss.Color("#92400e"),
 		markBg:    lipgloss.Color("#dbeafe"),
+		markFg:    lipgloss.Color("#1d4ed8"),
 	}
 }
 
@@ -317,6 +324,8 @@ func charmtoneLightDaltonizedPalette() themeColors {
 	p.addedFg = lipgloss.Color("#1d4ed8")
 	p.addedBg = lipgloss.Color("#dbeafe")
 	p.dimGreen = lipgloss.Color("#1e40af")
+	p.markBg = lipgloss.Color("#f3e8ff") // light purple — distinct from blue addedBg
+	p.markFg = lipgloss.Color("#7c3aed")
 	return p
 }
 
@@ -334,7 +343,8 @@ func githubDarkPalette() themeColors {
 		dimGreen:  lipgloss.Color("#196c2e"),
 		dimRed:    lipgloss.Color("#67060c"),
 		dimYellow: lipgloss.Color("#9e6a03"),
-		markBg:    lipgloss.Color("#0d1f3d"),
+		markBg:    lipgloss.Color("#1f4a8a"),
+		markFg:    lipgloss.Color("#58a6ff"),
 	}
 }
 
@@ -343,6 +353,8 @@ func githubDarkDaltonizedPalette() themeColors {
 	p.addedFg = lipgloss.Color("#58a6ff") // GitHub blue
 	p.addedBg = lipgloss.Color("#0d1f3d") // dark blue bg
 	p.dimGreen = lipgloss.Color("#1f6feb")
+	p.markBg = lipgloss.Color("#5a2d6e") // purple — distinct from blue addedBg
+	p.markFg = lipgloss.Color("#c084fc")
 	return p
 }
 
@@ -361,6 +373,7 @@ func githubLightPalette() themeColors {
 		dimRed:    lipgloss.Color("#9f1239"),
 		dimYellow: lipgloss.Color("#92400e"),
 		markBg:    lipgloss.Color("#dbeafe"),
+		markFg:    lipgloss.Color("#1d4ed8"),
 	}
 }
 
@@ -369,5 +382,7 @@ func githubLightDaltonizedPalette() themeColors {
 	p.addedFg = lipgloss.Color("#1d4ed8")
 	p.addedBg = lipgloss.Color("#dbeafe")
 	p.dimGreen = lipgloss.Color("#1e40af")
+	p.markBg = lipgloss.Color("#f3e8ff") // light purple — distinct from blue addedBg
+	p.markFg = lipgloss.Color("#7c3aed")
 	return p
 }


### PR DESCRIPTION
## Summary

- Make the mark highlight visible: brighten `markBg` across dark themes, switch daltonized themes to a purple `markBg`/`markFg` so they no longer collide with the blue "added" background.
- Render a colored `▌` bookmark stripe in the leading prefix column for marked lines (themed) and commented lines (yellow). Priority: cursor > comment > mark > blank.

Closes #173

## Test plan

- [x] `make` (lint + test) clean
- [ ] Mark a line — bright stripe at left edge, themed color
- [ ] Comment a line — yellow stripe at left edge
- [ ] Marked + commented line — yellow stripe wins, mark gutter bg still visible
- [ ] Cursor on a marked/commented line — `▶` shown instead of stripe
- [ ] All ten themes look reasonable, especially the four daltonized ones (verify mark no longer hides on blue addedBg)
- [ ] `NO_COLOR=1` mode still readable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marked lines now have brighter background highlighting plus a colored 1‑char stripe for improved visibility.
  * Commented lines display a yellow stripe that takes precedence over mark styling.
  * Cursor line shows a clear cursor glyph when focused.
  * Theme updates include daltonized color adjustments (purple mark color) to reduce visual conflicts and improve accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->