### PR TITLE
Adaptive refresh system: fsnotify wakeups + self-throttling cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - When a fresh branch diverges from default while revise is running (e.g. after a commit), the mode auto-promotes from Staged to Branch so new commits become visible, unless the user has explicitly picked a mode (#148)
 - Marked lines are now visibly distinct: brighter mark backgrounds and a colored `▌` bookmark stripe in the leading prefix column. Daltonized themes use a purple mark color so the highlight no longer collides with the blue "added" background (#173)
 - Commented lines also get a yellow `▌` bookmark stripe in the leading prefix column, matching the mark-line treatment (#173)
+- fswatch now installs a watch on newly-created directories on the fly, so `mkdir new-feature && touch new-feature/foo.go` triggers a refresh immediately instead of waiting for the next periodic poll (#144)
 - Auto-refresh now wakes on file changes (via fsnotify) and on terminal focus, instead of waiting up to 30s for the next polling tick. Cadence is adaptive — it self-throttles based on how long the last `git status` took, so running 10-20 revise instances on shared-repo worktrees no longer piles up I/O. Pass `--no-watch` (or set `REVISE_NO_WATCH=1`) to disable the fsnotify path and fall back to timer-only refreshes (#144)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - When a fresh branch diverges from default while revise is running (e.g. after a commit), the mode auto-promotes from Staged to Branch so new commits become visible, unless the user has explicitly picked a mode (#148)
 - Marked lines are now visibly distinct: brighter mark backgrounds and a colored `▌` bookmark stripe in the leading prefix column. Daltonized themes use a purple mark color so the highlight no longer collides with the blue "added" background (#173)
 - Commented lines also get a yellow `▌` bookmark stripe in the leading prefix column, matching the mark-line treatment (#173)
+- Auto-refresh now wakes on file changes (via fsnotify) and on terminal focus, instead of waiting up to 30s for the next polling tick. Cadence is adaptive — it self-throttles based on how long the last `git status` took, so running 10-20 revise instances on shared-repo worktrees no longer piles up I/O. Pass `--no-watch` (or set `REVISE_NO_WATCH=1`) to disable the fsnotify path and fall back to timer-only refreshes (#144)
+
+### Added
+
+- `--debug` flag shows a refresh-debug strip above the status bar with live timings: focus state, fsnotify on/off, polling status, time since the last fingerprint check / diff reload (with durations), time until the next scheduled tick, and a generation counter. Independent of `--dev`; the two compose freely (#144)
 
 ## [0.3.0] - 2026-04-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,12 @@ internal/
     format_test.go             # formatter tests
     diff_integration_test.go   # GetDiff/StagedDiff/etc integration tests (real git repos)
     testhelper_test.go         # TestRepo helper for integration tests
+  refresh/
+    policy.go                  # adaptive cadence policy (NextDelay, Debounce); pure logic
+    policy_test.go             # table-driven unit tests
+  fswatch/
+    watcher.go                 # fsnotify wrapper: watches tracked dirs + git dir, coalesces bursts
+    watcher_test.go            # integration tests using real git tempdirs
   comments/
     store.go                   # JSON persistence for comments (Save/Load/StorePath)
     store_test.go              # persistence unit tests
@@ -192,6 +198,16 @@ Bubbletea maps the Escape key to the string `"esc"` (not `"escape"`) — use `ca
 Comments are persisted to `os.TempDir()/revise/<hash>.json` where hash = `sha256(repoRoot + ":" + branchName)[:16]`. Auto-saved on every add/edit/delete, loaded on startup. The `internal/comments/` package handles storage; `internal/ui/comment.go` handles serialization between the internal `commentKey` struct and string-keyed JSON.
 
 File-level comments use `lineNum: 0` in the `commentKey` struct (diff line numbers are always >= 1). They are displayed at the top of the diff view before hunks, and exported as "File comment: ..." in the export format.
+
+### Auto-refresh
+
+Three pieces, each with one job:
+
+- **`internal/refresh/`** — pure cadence policy. `NextDelay(lastDuration)` clamps `multiplier × lastDuration` to `[Min, Max]` so cadence self-throttles when `git status` is slow (10-20 revise instances on worktrees of one repo cause I/O contention; see #129). `Debounce(lastStart, now)` returns the wait until the next refresh request can fire.
+- **`internal/fswatch/`** — fsnotify wrapper. Watches the parent directories of tracked files (via `git ls-files`, so it's gitignore-correct without walking node_modules) plus the git directory itself (filtered to `index`/`HEAD`). Coalesces event bursts into a single emitted `Event`.
+- **`internal/ui/model.go`** — wires them together. `requestRefresh()` is the single funnel for FocusMsg, fsEventMsg, and scheduled ticks. It bumps a `pollGen` counter on every request so any earlier in-flight `tea.Tick` becomes stale and is dropped (eliminates the "scheduled at +25s, focus at +24.9s" dead zone).
+
+The fs watcher is attached via `Model.WithFSWatcher(w)`. If `fswatch.New` fails (network FS, FD limits) or `--no-watch` / `REVISE_NO_WATCH=1` is set, the model gets no watcher and auto-refresh runs on a timer only.
 
 ### Diff Parsing
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creativeprojects/go-selfupdate v1.5.2
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/fswatch/watcher.go
+++ b/internal/fswatch/watcher.go
@@ -12,6 +12,7 @@ package fswatch
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -143,6 +144,7 @@ func (w *Watcher) run() {
 			if !ok {
 				return
 			}
+			w.maybeWatchNewDir(ev)
 			if !w.relevant(ev) {
 				continue
 			}
@@ -167,6 +169,9 @@ func (w *Watcher) run() {
 
 // drainBurst consumes events for w.coalesce duration without emitting,
 // so a flurry of related events results in only one downstream Event.
+// We still inspect each event for new-directory creates so a
+// `mkdir -p a/b/c && touch a/b/c/foo` burst leaves all of a/, a/b/,
+// a/b/c/ watched.
 func (w *Watcher) drainBurst() {
 	deadline := time.NewTimer(w.coalesce)
 	defer deadline.Stop()
@@ -180,9 +185,30 @@ func (w *Watcher) drainBurst() {
 			if !ok {
 				return
 			}
-			_ = ev // discarded — coalesced
+			w.maybeWatchNewDir(ev)
 		}
 	}
+}
+
+// maybeWatchNewDir installs a watch on a newly-created directory so
+// subsequent edits inside it fire events. Without this, the user's
+// `mkdir new-feature && touch new-feature/foo.go` would be invisible
+// to fsnotify until the next periodic poll picked it up — usually
+// fine, but slow on a 30s-clamped policy.
+//
+// We don't filter against gitignore here; gitignored content (e.g. an
+// errant `node_modules`) won't change `git status` output, so the
+// fingerprint check stays stable and no diff reload happens. The cost
+// is a few extra fsnotify watches.
+func (w *Watcher) maybeWatchNewDir(ev fsnotify.Event) {
+	if ev.Op&fsnotify.Create == 0 {
+		return
+	}
+	info, err := os.Stat(ev.Name)
+	if err != nil || !info.IsDir() {
+		return
+	}
+	_ = w.fsn.Add(ev.Name)
 }
 
 // relevant reports whether an fsnotify event should trigger a refresh.

--- a/internal/fswatch/watcher.go
+++ b/internal/fswatch/watcher.go
@@ -1,0 +1,202 @@
+// Package fswatch wakes the auto-refresh loop when working-tree files
+// or the git index change. It wraps fsnotify with two narrow concerns:
+// gitignore-correct directory selection (via `git ls-files`, so we
+// don't add watches for node_modules etc.) and burst coalescing (so
+// one editor save fires one Event, not four).
+//
+// The Watcher emits a content-free Event — a wakeup signal. The caller
+// is responsible for re-running git status / loadDiff and deciding
+// whether to surface a change. This keeps the watcher decoupled from
+// any UI or git-comparison logic.
+package fswatch
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Event is a wakeup signal — it carries no data. The caller re-checks
+// state via whatever primitive is appropriate (e.g. git.StatusFingerprint).
+type Event struct{}
+
+// Watcher emits Events when files in the working tree or git index change.
+// Use New to construct one and Events()/Close() to consume and shut down.
+type Watcher struct {
+	fsn      *fsnotify.Watcher
+	workTree string
+	gitDir   string
+	coalesce time.Duration
+
+	out chan Event
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+// New starts a watcher over the working tree and git directory.
+//
+// workTree should be the absolute repo root; gitDir should be the
+// worktree-aware git directory (`git rev-parse --git-dir`). The watcher
+// adds fsnotify watches on the gitDir itself plus the unique parent
+// directories of files reported by `git ls-files`. Recursion is
+// avoided — large unrelated subtrees (node_modules, build outputs)
+// are never watched because git already filters them.
+//
+// coalesce is the burst window: rapid events within coalesce of each
+// other collapse into a single emitted Event.
+//
+// On any error during setup, returns the error and the caller should
+// fall back to timer-only polling.
+func New(workTree, gitDir string, coalesce time.Duration) (*Watcher, error) {
+	if workTree == "" || gitDir == "" {
+		return nil, errors.New("fswatch: workTree and gitDir are required")
+	}
+	fsn, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Watcher{
+		fsn:      fsn,
+		workTree: workTree,
+		gitDir:   gitDir,
+		coalesce: coalesce,
+		out:      make(chan Event, 1),
+		done:     make(chan struct{}),
+	}
+
+	if err := fsn.Add(gitDir); err != nil {
+		_ = fsn.Close()
+		return nil, err
+	}
+
+	if err := w.addTrackedDirs(); err != nil {
+		_ = fsn.Close()
+		return nil, err
+	}
+
+	go w.run()
+	return w, nil
+}
+
+// Events returns the receive-only channel of wakeup events. The
+// channel is closed when the Watcher is Closed.
+func (w *Watcher) Events() <-chan Event { return w.out }
+
+// Close stops the watcher and releases its resources. Safe to call
+// multiple times.
+func (w *Watcher) Close() error {
+	var err error
+	w.closeOnce.Do(func() {
+		close(w.done)
+		err = w.fsn.Close()
+	})
+	return err
+}
+
+// addTrackedDirs adds fsnotify watches on the unique parent directories
+// of files reported by `git ls-files`. Failures on individual Adds are
+// non-fatal — a missing watch just means missed events for that dir,
+// not a broken watcher.
+func (w *Watcher) addTrackedDirs() error {
+	cmd := exec.Command("git", "-C", w.workTree, "ls-files")
+	out, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]struct{})
+	// Always watch the working tree root so top-level files are covered.
+	seen[w.workTree] = struct{}{}
+	_ = w.fsn.Add(w.workTree)
+
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		dir := filepath.Join(w.workTree, filepath.Dir(line))
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		_ = w.fsn.Add(dir)
+	}
+	return nil
+}
+
+// run is the watcher goroutine: it filters incoming fsnotify events,
+// coalesces bursts within w.coalesce, and emits one Event per burst.
+func (w *Watcher) run() {
+	defer close(w.out)
+
+	for {
+		select {
+		case <-w.done:
+			return
+		case ev, ok := <-w.fsn.Events:
+			if !ok {
+				return
+			}
+			if !w.relevant(ev) {
+				continue
+			}
+			// Drain further events within the coalesce window before
+			// emitting. This collapses editor-save bursts (vim's
+			// open/write/chmod/rename sequence) into one Event.
+			w.drainBurst()
+			select {
+			case w.out <- Event{}:
+			default:
+				// Channel buffer full — a previous Event hasn't been
+				// consumed yet. Dropping is fine: the consumer's next
+				// read still triggers a refresh that covers our event.
+			}
+		case <-w.fsn.Errors:
+			// fsnotify error channel — we don't surface these. A real
+			// failure (watcher closed) is observed via the Events
+			// channel close above.
+		}
+	}
+}
+
+// drainBurst consumes events for w.coalesce duration without emitting,
+// so a flurry of related events results in only one downstream Event.
+func (w *Watcher) drainBurst() {
+	deadline := time.NewTimer(w.coalesce)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-deadline.C:
+			return
+		case ev, ok := <-w.fsn.Events:
+			if !ok {
+				return
+			}
+			_ = ev // discarded — coalesced
+		}
+	}
+}
+
+// relevant reports whether an fsnotify event should trigger a refresh.
+// Events under gitDir only count if they touch index or HEAD; lockfiles,
+// commit message drafts, and ref churn are filtered out.
+func (w *Watcher) relevant(ev fsnotify.Event) bool {
+	if strings.HasPrefix(ev.Name, w.gitDir) {
+		base := filepath.Base(ev.Name)
+		switch base {
+		case "index", "HEAD":
+			return true
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/fswatch/watcher_test.go
+++ b/internal/fswatch/watcher_test.go
@@ -160,6 +160,31 @@ func TestWatcher_CoalescesBurst(t *testing.T) {
 	expectNoEvent(t, w, 200*time.Millisecond)
 }
 
+func TestWatcher_FiresOnFileInNewlyCreatedDir(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "foo.go", "package main\n")
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+	defer w.Close() //nolint:errcheck
+
+	// `mkdir new-feature && touch new-feature/foo.go` — the dir didn't
+	// exist when New ran, so it wasn't in the initial watch set. The
+	// watcher must pick it up dynamically, otherwise the second event
+	// (file write inside the new dir) is invisible.
+	require.NoError(t, os.MkdirAll(filepath.Join(workTree, "new-feature"), 0o755))
+
+	// Drain the CREATE-of-dir event itself.
+	expectEvent(t, w, 1*time.Second)
+
+	// Give the watcher a moment to install the dynamic watch on
+	// new-feature/ before we write inside it.
+	time.Sleep(50 * time.Millisecond)
+
+	writeFile(t, filepath.Join(workTree, "new-feature", "foo.go"), "package newfeature\n")
+	expectEvent(t, w, 1*time.Second)
+}
+
 func TestWatcher_CloseIsIdempotent(t *testing.T) {
 	workTree, gitDir := gitInit(t)
 	commitFile(t, workTree, "foo.go", "package main\n")

--- a/internal/fswatch/watcher_test.go
+++ b/internal/fswatch/watcher_test.go
@@ -1,0 +1,204 @@
+package fswatch
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCoalesce is the coalesce window used in tests — short so tests run fast.
+const testCoalesce = 20 * time.Millisecond
+
+// gitInit creates a fresh repo at dir, configures it for commits, and
+// returns the resolved gitDir (worktree-aware via rev-parse).
+func gitInit(t *testing.T) (workTree, gitDir string) {
+	t.Helper()
+	workTree = t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"symbolic-ref", "HEAD", "refs/heads/main"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = workTree
+		require.NoError(t, cmd.Run(), "git %s", strings.Join(args, " "))
+	}
+
+	out, err := runGit(workTree, "rev-parse", "--git-dir")
+	require.NoError(t, err)
+	gitDir = strings.TrimSpace(out)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(workTree, gitDir)
+	}
+	return workTree, gitDir
+}
+
+func runGit(workTree string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workTree
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func commitFile(t *testing.T, workTree, relPath, content string) {
+	t.Helper()
+	writeFile(t, filepath.Join(workTree, relPath), content)
+	_, err := runGit(workTree, "add", relPath)
+	require.NoError(t, err)
+	_, err = runGit(workTree, "commit", "-m", "add "+relPath)
+	require.NoError(t, err)
+}
+
+// expectEvent waits up to timeout for an Event on w.Events(), failing
+// the test if none arrives.
+func expectEvent(t *testing.T, w *Watcher, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-w.Events():
+	case <-time.After(timeout):
+		t.Fatal("expected fswatch Event within", timeout)
+	}
+}
+
+// expectNoEvent ensures no Event arrives within timeout.
+func expectNoEvent(t *testing.T, w *Watcher, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-w.Events():
+		t.Fatal("expected no fswatch Event, but one arrived")
+	case <-time.After(timeout):
+	}
+}
+
+func TestWatcher_FiresOnTrackedFileEdit(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "foo.go", "package main\n")
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+	defer w.Close() //nolint:errcheck
+
+	writeFile(t, filepath.Join(workTree, "foo.go"), "package main\n// edited\n")
+	expectEvent(t, w, 1*time.Second)
+}
+
+func TestWatcher_FiresOnNewFileInTrackedDir(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "pkg/a.go", "package pkg\n")
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+	defer w.Close() //nolint:errcheck
+
+	writeFile(t, filepath.Join(workTree, "pkg", "b.go"), "package pkg\n")
+	expectEvent(t, w, 1*time.Second)
+}
+
+func TestWatcher_FiresOnIndexChange(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "foo.go", "package main\n")
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+	defer w.Close() //nolint:errcheck
+
+	// Drain any startup-induced events.
+	drainEvents(w, 50*time.Millisecond)
+
+	writeFile(t, filepath.Join(workTree, "bar.go"), "package main\n")
+	_, err = runGit(workTree, "add", "bar.go")
+	require.NoError(t, err)
+
+	expectEvent(t, w, 1*time.Second)
+}
+
+func TestWatcher_IgnoresUnrelatedGitDirFiles(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "foo.go", "package main\n")
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+	defer w.Close() //nolint:errcheck
+
+	drainEvents(w, 50*time.Millisecond)
+
+	// Touch an unrelated file inside .git that shouldn't trigger refresh.
+	writeFile(t, filepath.Join(gitDir, "COMMIT_EDITMSG"), "draft message\n")
+	expectNoEvent(t, w, 200*time.Millisecond)
+}
+
+func TestWatcher_CoalescesBurst(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "foo.go", "package main\n")
+
+	w, err := New(workTree, gitDir, 100*time.Millisecond)
+	require.NoError(t, err)
+	defer w.Close() //nolint:errcheck
+
+	drainEvents(w, 50*time.Millisecond)
+
+	// Many rapid writes within the coalesce window should collapse into 1 Event.
+	for i := 0; i < 5; i++ {
+		writeFile(t, filepath.Join(workTree, "foo.go"), "edit "+string(rune('a'+i))+"\n")
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	expectEvent(t, w, 1*time.Second)
+	expectNoEvent(t, w, 200*time.Millisecond)
+}
+
+func TestWatcher_CloseIsIdempotent(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "foo.go", "package main\n")
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+
+	assert.NoError(t, w.Close())
+	assert.NoError(t, w.Close(), "second Close should be a no-op")
+}
+
+func TestWatcher_NoEventsAfterClose(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "foo.go", "package main\n")
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	writeFile(t, filepath.Join(workTree, "foo.go"), "edited\n")
+
+	// Events channel should be closed; reading yields zero value immediately.
+	select {
+	case _, ok := <-w.Events():
+		assert.False(t, ok, "Events channel should be closed after Close")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Events channel was not closed after Close")
+	}
+}
+
+// drainEvents reads any pending Events for d duration, discarding them.
+// Used to clear startup noise before a test makes its own changes.
+func drainEvents(w *Watcher, d time.Duration) {
+	deadline := time.After(d)
+	for {
+		select {
+		case <-w.Events():
+		case <-deadline:
+			return
+		}
+	}
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -179,6 +179,18 @@ func RepoRoot() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// GitDir returns the absolute path to the git directory for the current
+// working tree. In a worktree this is `<main-repo>/.git/worktrees/<name>/`,
+// not the worktree's `.git` file. Used by fswatch to monitor index/HEAD
+// changes (per-worktree, not the main repo's).
+func GitDir() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--absolute-git-dir").Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse --absolute-git-dir: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // IsGitRepo checks if the current directory is inside a git repository.
 func IsGitRepo() bool {
 	err := exec.Command("git", "rev-parse", "--is-inside-work-tree").Run()

--- a/internal/refresh/policy.go
+++ b/internal/refresh/policy.go
@@ -1,0 +1,64 @@
+// Package refresh provides cadence policy for revise's auto-refresh loop.
+//
+// The Policy type decides two things: how long to wait until the next
+// scheduled poll (based on the duration of the last one — adaptive
+// back-off when git ops are slow), and whether an externally-requested
+// refresh (focus, fsnotify event, etc.) can fire now or must wait for
+// debounce. The logic is pure — no time.Now in NextDelay, no goroutines,
+// no UI dependencies — so it's trivially testable in isolation.
+package refresh
+
+import "time"
+
+// Policy controls auto-refresh cadence.
+type Policy struct {
+	// Min is the floor for any inter-poll delay. Refreshes can never
+	// fire faster than once per Min; this is the debounce window.
+	Min time.Duration
+
+	// Max is the ceiling for any inter-poll delay. Even when the last
+	// poll was very slow, the next one fires no later than Max from now.
+	Max time.Duration
+
+	// Multiplier sets the back-off curve: NextDelay is the last poll's
+	// duration times Multiplier, clamped to [Min, Max]. A value of 5
+	// keeps the steady-state poll cost at roughly 1/5 of total time.
+	Multiplier int
+}
+
+// Default is the policy used when no override is provided.
+var Default = Policy{
+	Min:        2 * time.Second,
+	Max:        30 * time.Second,
+	Multiplier: 5,
+}
+
+// NextDelay returns how long to wait before the next scheduled poll,
+// given how long the previous poll took. Scales with lastDuration so
+// that under contention (10-20 instances slowing each other down) the
+// cadence self-throttles instead of stacking I/O.
+func (p Policy) NextDelay(lastDuration time.Duration) time.Duration {
+	next := lastDuration * time.Duration(p.Multiplier)
+	if next < p.Min {
+		next = p.Min
+	}
+	if next > p.Max {
+		next = p.Max
+	}
+	return next
+}
+
+// Debounce returns how long an externally-requested refresh must wait
+// before it can fire, given when the last poll started. Returns 0 if
+// it can fire immediately. Used by the FocusMsg / fsEvent paths so a
+// burst of triggers collapses into one poll.
+func (p Policy) Debounce(lastStart, now time.Time) time.Duration {
+	if lastStart.IsZero() {
+		return 0
+	}
+	elapsed := now.Sub(lastStart)
+	if elapsed >= p.Min {
+		return 0
+	}
+	return p.Min - elapsed
+}

--- a/internal/refresh/policy_test.go
+++ b/internal/refresh/policy_test.go
@@ -1,0 +1,61 @@
+package refresh
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicy_NextDelay(t *testing.T) {
+	p := Policy{Min: 2 * time.Second, Max: 30 * time.Second, Multiplier: 5}
+
+	cases := []struct {
+		name         string
+		lastDuration time.Duration
+		want         time.Duration
+	}{
+		{"zero duration clamps to Min", 0, 2 * time.Second},
+		{"very fast clamps to Min", 100 * time.Millisecond, 2 * time.Second},
+		{"in-band scales by multiplier", 1 * time.Second, 5 * time.Second},
+		{"larger in-band", 3 * time.Second, 15 * time.Second},
+		{"at boundary stays in-band", 6 * time.Second, 30 * time.Second},
+		{"slow clamps to Max", 10 * time.Second, 30 * time.Second},
+		{"very slow clamps to Max", 1 * time.Minute, 30 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, p.NextDelay(tc.lastDuration))
+		})
+	}
+}
+
+func TestPolicy_Debounce(t *testing.T) {
+	p := Policy{Min: 2 * time.Second, Max: 30 * time.Second, Multiplier: 5}
+	now := time.Now()
+
+	cases := []struct {
+		name      string
+		lastStart time.Time
+		want      time.Duration
+	}{
+		{"zero lastStart fires immediately", time.Time{}, 0},
+		{"long ago fires immediately", now.Add(-10 * time.Second), 0},
+		{"exactly Min ago fires immediately", now.Add(-2 * time.Second), 0},
+		{"recent waits remainder", now.Add(-500 * time.Millisecond), 1500 * time.Millisecond},
+		{"just now waits ~Min", now.Add(-1 * time.Millisecond), 1999 * time.Millisecond},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.Debounce(tc.lastStart, now)
+			// Tolerate small drift on the "just now" math
+			assert.InDelta(t, tc.want.Nanoseconds(), got.Nanoseconds(), float64(2*time.Millisecond.Nanoseconds()))
+		})
+	}
+}
+
+func TestPolicy_Default(t *testing.T) {
+	assert.Equal(t, 2*time.Second, Default.Min)
+	assert.Equal(t, 30*time.Second, Default.Max)
+	assert.Equal(t, 5, Default.Multiplier)
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -11,22 +11,37 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	commentstore "github.com/justincampbell/revise/internal/comments"
+	"github.com/justincampbell/revise/internal/fswatch"
 	"github.com/justincampbell/revise/internal/git"
+	"github.com/justincampbell/revise/internal/refresh"
 	"github.com/justincampbell/revise/internal/update"
 )
 
 type clearStatusMsg struct{}
 
-// pollTickMsg triggers a periodic check for working tree changes.
-type pollTickMsg struct{}
-
-// pollResultMsg carries the result of a fingerprint check.
-type pollResultMsg struct {
-	fingerprint string
-	err         error
+// refreshTickMsg triggers a fingerprint check. The gen field is a
+// generation counter — when requestRefresh schedules a new poll, it
+// bumps gen so any earlier in-flight tea.Tick is invalidated. This
+// removes the dead zone where a long-pending tick would block a more
+// recent focus/fsEvent from firing right away.
+type refreshTickMsg struct {
+	gen uint64
 }
 
-const pollInterval = 30 * time.Second
+// refreshResultMsg carries the result of a fingerprint check, plus how
+// long it took. The duration feeds the adaptive cadence in
+// refresh.Policy: slow polls schedule the next tick further out so 10-20
+// concurrent revise instances on shared-repo worktrees don't pile up I/O.
+type refreshResultMsg struct {
+	fingerprint string
+	err         error
+	duration    time.Duration
+}
+
+// fsEventMsg is delivered when fswatch.Watcher reports a change. The
+// handler must re-issue the listen command in exactly one place to keep
+// the channel pump alive.
+type fsEventMsg struct{}
 
 // hunkApplyMsg is sent when an async hunk stage/unstage/discard completes.
 type hunkApplyMsg struct {
@@ -54,8 +69,14 @@ type diffLoadedMsg struct {
 	diff            *git.Diff
 	err             error
 	onDefaultBranch bool
-	fromPoll        bool // true when triggered by auto-refresh polling
+	fromPoll        bool          // true when triggered by auto-refresh polling
+	duration        time.Duration // time the diff load took (used by --debug overlay)
 }
+
+// debugTickMsg fires once per second in --debug mode so the debug strip
+// can re-render with up-to-date "Xs ago" / "next in Ys" values without
+// waiting for an unrelated message to redraw the screen.
+type debugTickMsg struct{}
 
 // DiffMode represents which diff view is active.
 // Modes are cumulative: Unstaged is always included,
@@ -112,9 +133,25 @@ type Model struct {
 
 	confirmClear bool // waiting for confirmation to clear all comments
 
-	lastFingerprint string // last seen git status fingerprint for auto-refresh
-	polling         bool   // true while a fingerprint check is in flight
-	focused         bool   // true when the terminal has focus; polling pauses on blur
+	// Auto-refresh state. The flow is:
+	//   FocusMsg / fsEventMsg / scheduled tick → requestRefresh()
+	//     → refreshTickMsg (if not stale, not polling, focused)
+	//     → fingerprint check → refreshResultMsg
+	//     → if changed: loadDiffFromPoll()
+	//     → schedule next tick via refreshPolicy.NextDelay(lastPollDuration)
+	// pollGen invalidates earlier-scheduled ticks (see refreshTickMsg).
+	refreshPolicy        refresh.Policy
+	lastFingerprint      string
+	lastPollStart        time.Time
+	lastPollDuration     time.Duration
+	lastDiffLoadStart    time.Time
+	lastDiffLoadDuration time.Duration
+	nextTickAt           time.Time // when the next scheduled refreshTickMsg is due (for --debug overlay)
+	polling              bool
+	focused              bool
+	pollGen              uint64
+	fsWatcher            *fswatch.Watcher // nil if disabled or init failed
+	debug                bool             // true in --debug mode; renders refresh debug strip
 
 	currentVersion string              // version string from build
 	updateInfo     *update.UpdateInfo  // populated after update check
@@ -202,18 +239,52 @@ func NewWithStorePath(diff *git.Diff, onDefaultBranch bool, storePath string, ve
 		mode:            mode,
 		onDefaultBranch: onDefaultBranch,
 		contextLines:    git.DefaultContextLines,
+		refreshPolicy:   refresh.Default,
 		lastFingerprint: initialFP,
 		focused:         true,
 		currentVersion:  version,
 	}
 }
 
+// WithFSWatcher attaches an fswatch.Watcher so file changes wake the
+// refresh loop directly, instead of waiting for the next scheduled tick.
+// Pass nil (or skip the call) for timer-only auto-refresh — that's the
+// fallback when fswatch.New fails or the user passed --no-watch.
+func (m Model) WithFSWatcher(w *fswatch.Watcher) Model {
+	m.fsWatcher = w
+	return m
+}
+
+// WithDebug enables the refresh-debug strip above the status bar. It
+// shows live refresh timings: time since the last fingerprint check and
+// diff reload, durations of those operations, time until the next
+// scheduled tick, and whether fsnotify is wired up. Useful for tuning
+// refresh.Policy or debugging "why isn't this updating".
+//
+// Independent of --dev: --dev auto-restarts on binary replacement,
+// --debug surfaces refresh internals. They compose freely.
+func (m Model) WithDebug(debug bool) Model {
+	m.debug = debug
+	return m
+}
+
 func (m Model) Init() tea.Cmd {
 	if m.fileReviewMode {
 		return nil
 	}
+	// Schedule the first auto-refresh tick. pollGen=0 so a fresh tick
+	// (also gen=0) is accepted; subsequent requestRefresh calls bump
+	// the counter and supersede this one.
 	cmds := []tea.Cmd{
-		tea.Tick(pollInterval, func(time.Time) tea.Msg { return pollTickMsg{} }),
+		tea.Tick(m.refreshPolicy.Min, func(time.Time) tea.Msg {
+			return refreshTickMsg{gen: 0}
+		}),
+	}
+	if cmd := listenFSEvents(m.fsWatcher); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	if m.debug {
+		cmds = append(cmds, tea.Tick(time.Second, func(time.Time) tea.Msg { return debugTickMsg{} }))
 	}
 	if m.currentVersion != "" && update.IsSemver(m.currentVersion) {
 		ver := m.currentVersion
@@ -525,6 +596,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case diffLoadedMsg:
+		m.lastDiffLoadDuration = msg.duration
 		if msg.err != nil {
 			m.statusMsg = "Error: " + msg.err.Error()
 			return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
@@ -608,27 +680,45 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusMsg = ""
 		return m, nil
 
+	case debugTickMsg:
+		// In --debug mode, drive a once-per-second redraw so the debug
+		// strip's relative timestamps stay current. Outside --debug the
+		// tick is never scheduled, so this is dead code at runtime.
+		if !m.debug {
+			return m, nil
+		}
+		return m, tea.Tick(time.Second, func(time.Time) tea.Msg { return debugTickMsg{} })
+
 	case tea.FocusMsg:
 		m.focused = true
-		// Resume polling now that we have focus again.
-		return m, tea.Tick(pollInterval, func(time.Time) tea.Msg { return pollTickMsg{} })
+		return m, m.requestRefresh()
 
 	case tea.BlurMsg:
 		m.focused = false
 		return m, nil
 
-	case pollTickMsg:
-		// Skip if unfocused or if a fingerprint check is already in
-		// flight to avoid piling up git status processes (see #129).
-		// On blur, polling stops entirely; FocusMsg restarts it.
-		// The in-flight check's pollResultMsg will schedule the next tick.
-		if !m.focused || m.polling {
+	case fsEventMsg:
+		// File changed under the watcher. Request a refresh (subject to
+		// debounce) and re-issue the listen Cmd to keep the channel
+		// pump alive. The re-issue lives here, in exactly one place.
+		return m, tea.Batch(m.requestRefresh(), listenFSEvents(m.fsWatcher))
+
+	case refreshTickMsg:
+		// Drop ticks superseded by a later requestRefresh (gen counter).
+		// Drop if a check is already in flight or we're unfocused.
+		if msg.gen != m.pollGen || m.polling || !m.focused {
 			return m, nil
 		}
 		m.polling = true
+		m.lastPollStart = time.Now()
+		start := m.lastPollStart
 		return m, func() tea.Msg {
 			fp, err := git.StatusFingerprint()
-			return pollResultMsg{fingerprint: fp, err: err}
+			return refreshResultMsg{
+				fingerprint: fp,
+				err:         err,
+				duration:    time.Since(start),
+			}
 		}
 
 	case untrackedCacheTipMsg:
@@ -653,12 +743,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusMsg = fmt.Sprintf("Updated to %s — restart revise to use the new version", msg.newVersion)
 		return m, tea.Tick(10*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
 
-	case pollResultMsg:
+	case refreshResultMsg:
 		m.polling = false
-		// Don't schedule the next tick if unfocused; FocusMsg will restart it.
+		m.lastPollDuration = msg.duration
+		// Schedule next tick at policy.NextDelay(duration) so cadence
+		// self-throttles under contention (10-20 instances). On blur
+		// we don't reschedule; FocusMsg will request the next refresh.
 		var nextTick tea.Cmd
 		if m.focused {
-			nextTick = tea.Tick(pollInterval, func(time.Time) tea.Msg { return pollTickMsg{} })
+			m.pollGen++
+			gen := m.pollGen
+			delay := m.refreshPolicy.NextDelay(msg.duration)
+			m.nextTickAt = time.Now().Add(delay)
+			nextTick = tea.Tick(delay, func(time.Time) tea.Msg {
+				return refreshTickMsg{gen: gen}
+			})
+		} else {
+			m.nextTickAt = time.Time{}
 		}
 		if msg.err != nil {
 			return m, nextTick
@@ -678,6 +779,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *Model) updateLayout() {
 	panelH := m.height - 3 // leave 1 row for status bar
+	if m.debug {
+		panelH-- // debug strip sits directly above the status bar
+	}
 
 	if m.fullscreen {
 		m.diffView.width = m.width - 2
@@ -1227,6 +1331,51 @@ func (m *Model) cycleMode(direction int) {
 	m.modeExplicitlySet = true
 }
 
+// requestRefresh is the single funnel for "something says state may have
+// changed — please poll" (FocusMsg, fsEventMsg, etc.). It bumps pollGen
+// so any earlier scheduled tick is invalidated, then either fires a
+// refreshTickMsg right away (if debounce permits) or schedules one for
+// when debounce expires.
+//
+// Returns nil when an in-flight poll is already running — its result
+// will reschedule the next tick, so a duplicate request is redundant.
+func (m *Model) requestRefresh() tea.Cmd {
+	if m.polling {
+		return nil
+	}
+	m.pollGen++
+	gen := m.pollGen
+	now := time.Now()
+	wait := m.refreshPolicy.Debounce(m.lastPollStart, now)
+	if wait == 0 {
+		m.nextTickAt = now
+		return func() tea.Msg { return refreshTickMsg{gen: gen} }
+	}
+	m.nextTickAt = now.Add(wait)
+	return tea.Tick(wait, func(time.Time) tea.Msg { return refreshTickMsg{gen: gen} })
+}
+
+// listenFSEvents returns a Cmd that blocks on the watcher's Events
+// channel and emits one fsEventMsg per Event. The fsEventMsg handler is
+// responsible for re-issuing this Cmd to keep the pump alive — and that
+// is the only place that re-issues, to avoid double-listen races.
+//
+// Returns nil if the watcher is disabled (nil) so callers can safely
+// batch unconditionally.
+func listenFSEvents(w *fswatch.Watcher) tea.Cmd {
+	if w == nil {
+		return nil
+	}
+	ch := w.Events()
+	return func() tea.Msg {
+		_, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return fsEventMsg{}
+	}
+}
+
 // loadDiff returns a command that fetches the diff for the current mode.
 func (m *Model) loadDiff() tea.Cmd {
 	return m.loadDiffWithOptions(false)
@@ -1242,6 +1391,8 @@ func (m *Model) loadDiffWithOptions(fromPoll bool) tea.Cmd {
 	mode := m.mode
 	ctx := m.contextLines
 	hideWS := m.hideWhitespace
+	m.lastDiffLoadStart = time.Now()
+	start := m.lastDiffLoadStart
 	return func() tea.Msg {
 		// Re-check whether we're on the default branch so the UI can
 		// enable/disable Branch mode dynamically (e.g. after git checkout -b).
@@ -1259,7 +1410,7 @@ func (m *Model) loadDiffWithOptions(fromPoll bool) tea.Cmd {
 		case ModeUnstaged:
 			diff, err = git.UnstagedOnlyDiffOptions(ctx, hideWS)
 		}
-		return diffLoadedMsg{diff: diff, err: err, onDefaultBranch: onDefault, fromPoll: fromPoll}
+		return diffLoadedMsg{diff: diff, err: err, onDefaultBranch: onDefault, fromPoll: fromPoll, duration: time.Since(start)}
 	}
 }
 
@@ -1320,6 +1471,107 @@ func (m Model) renderModeSlider() string {
 	return result
 }
 
+// renderDebugStrip is the --debug mode strip above the status bar. It
+// surfaces refresh timings live so you can answer "is auto-refresh
+// working?" / "why is the policy backing off so far?" without grepping
+// logs. Empty string when not in --debug mode.
+func (m Model) renderDebugStrip() string {
+	if !m.debug {
+		return ""
+	}
+
+	now := time.Now()
+
+	field := func(label, value string) string {
+		return devLabelStyle.Render(label+":") + " " + devValueStyle.Render(value)
+	}
+
+	fs := "off"
+	if m.fsWatcher != nil {
+		fs = "on"
+	}
+	focus := "blur"
+	if m.focused {
+		focus = "focus"
+	}
+	polling := "idle"
+	if m.polling {
+		polling = "in-flight"
+	}
+
+	// "next" shows what's actually going to happen, not just the
+	// scheduled tick time: while polling, the tick is moot (a poll
+	// is already running); while blurred, no tick will fire until
+	// FocusMsg requests one. Without these overrides, a tick that
+	// fires-and-drops (e.g. blurred) leaves nextTickAt in the past
+	// and the field reads "now" forever.
+	var nextDisplay string
+	switch {
+	case m.polling:
+		nextDisplay = "polling…"
+	case !m.focused:
+		nextDisplay = "blurred"
+	default:
+		nextDisplay = untilOrDash(m.nextTickAt, now)
+	}
+
+	parts := []string{
+		devLabelStyle.Render("[DEV]"),
+		field("focus", focus),
+		field("fs", fs),
+		field("status", polling),
+		field("poll", agoAndDur(m.lastPollStart, m.lastPollDuration, now)),
+		field("diff", agoAndDur(m.lastDiffLoadStart, m.lastDiffLoadDuration, now)),
+		field("next", nextDisplay),
+		field("gen", fmt.Sprintf("%d", m.pollGen)),
+	}
+
+	return statusBarStyle.Width(m.width).Render(strings.Join(parts, "  "))
+}
+
+// agoAndDur formats "Xs ago (Yms)" — when an operation last started and
+// how long it took. Returns "—" if the operation has never run.
+func agoAndDur(start time.Time, dur time.Duration, now time.Time) string {
+	if start.IsZero() {
+		return "—"
+	}
+	return fmt.Sprintf("%s ago (%s)", shortDuration(now.Sub(start)), shortDuration(dur))
+}
+
+// untilOrDash formats "Xs" until a future time, or "now" if past, or "—"
+// if zero. Used for the "next scheduled tick" indicator.
+func untilOrDash(t, now time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	d := t.Sub(now)
+	if d <= 0 {
+		return "now"
+	}
+	return shortDuration(d)
+}
+
+// shortDuration is a compact form of d for the debug strip:
+//   - sub-millisecond shows microseconds (e.g. "320µs")
+//   - sub-second shows milliseconds (e.g. "45ms")
+//   - sub-minute shows seconds with one decimal (e.g. "2.3s")
+//   - longer shows minutes (e.g. "3m12s")
+func shortDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Millisecond:
+		return fmt.Sprintf("%dµs", d.Microseconds())
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	default:
+		return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+}
+
 func (m Model) renderStatusBar() string {
 	if m.commentInputActive {
 		hint := helpKeyStyle.Render("Enter") + statusBarStyle.Render(": save  ") +
@@ -1349,21 +1601,30 @@ func (m Model) View() string {
 	}
 
 	statusBar := m.renderStatusBar()
+	debugStrip := m.renderDebugStrip()
 
 	slider := m.renderModeSlider()
 	if m.fileReviewMode {
 		slider = m.fileReviewPath
 	}
 
+	bottomChunks := []string{statusBar}
+	if debugStrip != "" {
+		// Debug strip sits directly above the status bar. updateLayout()
+		// shrinks panel height by one row when m.debug is true so the
+		// debug strip doesn't overflow the screen.
+		bottomChunks = []string{debugStrip, statusBar}
+	}
+
 	var screen string
 	if m.fullscreen {
 		panels := m.diffView.render(true, m.contextLines, m.hideWhitespace, slider)
-		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
+		screen = lipgloss.JoinVertical(lipgloss.Left, append([]string{panels}, bottomChunks...)...)
 	} else {
 		left := m.fileList.render(m.focus == focusFileList, slider)
 		right := m.diffView.render(m.focus == focusDiffView, m.contextLines, m.hideWhitespace)
 		panels := lipgloss.JoinHorizontal(lipgloss.Top, left, " ", right)
-		screen = lipgloss.JoinVertical(lipgloss.Left, panels, statusBar)
+		screen = lipgloss.JoinVertical(lipgloss.Left, append([]string{panels}, bottomChunks...)...)
 	}
 
 	if m.confirmDiscard || m.confirmClear {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1499,20 +1499,20 @@ func TestUpdateApplied_SetsStatusAndClearsAfterTimeout(t *testing.T) {
 	assert.NotNil(t, cmd, "should return a clear timer command")
 }
 
-func TestPollResult_SameFingerprint_NoReload(t *testing.T) {
+func TestRefreshResult_SameFingerprint_NoReload(t *testing.T) {
 	m := makeModel("a.go")
 	m.lastFingerprint = "M a.go\n"
 
-	updated, cmd := m.Update(pollResultMsg{fingerprint: "M a.go\n"})
+	updated, cmd := m.Update(refreshResultMsg{fingerprint: "M a.go\n", duration: 100 * time.Millisecond})
 	m = updated.(Model)
 	assert.NotNil(t, cmd, "same fingerprint should still schedule next tick")
 }
 
-func TestPollResult_DifferentFingerprint_TriggersReload(t *testing.T) {
+func TestRefreshResult_DifferentFingerprint_TriggersReload(t *testing.T) {
 	m := makeModel("a.go")
 	m.lastFingerprint = "M a.go\n"
 
-	updated, cmd := m.Update(pollResultMsg{fingerprint: "M a.go\n?? new.go\n"})
+	updated, cmd := m.Update(refreshResultMsg{fingerprint: "M a.go\n?? new.go\n", duration: 100 * time.Millisecond})
 	m = updated.(Model)
 	assert.NotNil(t, cmd, "different fingerprint should trigger a reload")
 	assert.Equal(t, "M a.go\n?? new.go\n", m.lastFingerprint)
@@ -1543,42 +1543,52 @@ func TestPollRefresh_PreservesCursorPosition(t *testing.T) {
 	assert.Equal(t, savedOffset, m.diffView.offset, "poll refresh should preserve offset")
 }
 
-func TestPollResult_Error_NoReload(t *testing.T) {
+func TestRefreshResult_Error_NoReload(t *testing.T) {
 	m := makeModel("a.go")
 	m.lastFingerprint = "M a.go\n"
 
-	_, cmd := m.Update(pollResultMsg{err: fmt.Errorf("git error")})
+	_, cmd := m.Update(refreshResultMsg{err: fmt.Errorf("git error"), duration: 50 * time.Millisecond})
 	assert.NotNil(t, cmd, "error should still schedule next tick")
 }
 
-func TestPollTick_SetsPollingFlag(t *testing.T) {
+func TestRefreshTick_SetsPollingFlag(t *testing.T) {
 	m := makeModel("a.go")
 	assert.False(t, m.polling)
 
-	updated, cmd := m.Update(pollTickMsg{})
+	updated, cmd := m.Update(refreshTickMsg{gen: m.pollGen})
 	m = updated.(Model)
 	assert.True(t, m.polling, "polling flag should be set")
 	assert.NotNil(t, cmd, "should return fingerprint check command")
 }
 
-func TestPollTick_SkipsWhenAlreadyPolling(t *testing.T) {
+func TestRefreshTick_SkipsWhenAlreadyPolling(t *testing.T) {
 	m := makeModel("a.go")
 	m.polling = true
 
-	updated, cmd := m.Update(pollTickMsg{})
+	updated, cmd := m.Update(refreshTickMsg{gen: m.pollGen})
 	m = updated.(Model)
 	assert.True(t, m.polling, "polling flag should remain true")
 	assert.Nil(t, cmd, "should not schedule anything when already polling")
 }
 
-func TestPollTick_SkipsWhenUnfocused(t *testing.T) {
+func TestRefreshTick_SkipsWhenUnfocused(t *testing.T) {
 	m := makeModel("a.go")
 	m.focused = false
 
-	updated, cmd := m.Update(pollTickMsg{})
+	updated, cmd := m.Update(refreshTickMsg{gen: m.pollGen})
 	m = updated.(Model)
 	assert.False(t, m.polling, "should not start polling when unfocused")
 	assert.Nil(t, cmd, "should not schedule anything when unfocused")
+}
+
+func TestRefreshTick_StaleGenIsDropped(t *testing.T) {
+	m := makeModel("a.go")
+	m.pollGen = 5
+
+	updated, cmd := m.Update(refreshTickMsg{gen: 3})
+	m = updated.(Model)
+	assert.False(t, m.polling, "stale tick should not start a poll")
+	assert.Nil(t, cmd, "stale tick should not produce a command")
 }
 
 func TestBlur_StopsPolling(t *testing.T) {
@@ -1601,31 +1611,138 @@ func TestFocus_ResumesPolling(t *testing.T) {
 	assert.NotNil(t, cmd, "focus should schedule a poll tick")
 }
 
-func TestPollResult_SkipsNextTickWhenUnfocused(t *testing.T) {
+func TestFocus_PollsImmediately(t *testing.T) {
+	m := makeModel("a.go")
+	m.focused = false
+
+	_, cmd := m.Update(tea.FocusMsg{})
+	require.NotNil(t, cmd, "focus should return a command")
+
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+	select {
+	case msg := <-done:
+		_, ok := msg.(refreshTickMsg)
+		assert.True(t, ok, "focus should fire refreshTickMsg immediately, got %T", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("focus did not fire refreshTickMsg within 500ms — likely scheduled via tea.Tick instead")
+	}
+}
+
+func TestFSEvent_RequestsRefreshAndRelistens(t *testing.T) {
+	m := makeModel("a.go")
+
+	// No watcher attached, so listenFSEvents returns nil; the relisten
+	// path is exercised in main.go integration. This test focuses on the
+	// requestRefresh side: an fsEvent should produce a Cmd that fires a
+	// refreshTickMsg promptly (subject to debounce — and lastPollStart is
+	// zero so debounce permits immediate firing).
+	_, cmd := m.Update(fsEventMsg{})
+	require.NotNil(t, cmd, "fsEventMsg should request a refresh")
+
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+	select {
+	case msg := <-done:
+		_, ok := msg.(refreshTickMsg)
+		assert.True(t, ok, "fsEvent should fire refreshTickMsg immediately, got %T", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("fsEvent did not produce refreshTickMsg promptly")
+	}
+}
+
+func TestRequestRefresh_SkipsWhilePolling(t *testing.T) {
+	m := makeModel("a.go")
+	m.polling = true
+
+	_, cmd := m.Update(tea.FocusMsg{})
+	assert.Nil(t, cmd, "in-flight poll should suppress new requests; result will reschedule")
+}
+
+func TestRequestRefresh_BumpsGenToInvalidateOldTicks(t *testing.T) {
+	m := makeModel("a.go")
+	startGen := m.pollGen
+
+	updated, _ := m.Update(tea.FocusMsg{})
+	m = updated.(Model)
+	gen1 := m.pollGen
+	assert.Greater(t, gen1, startGen, "FocusMsg should bump pollGen")
+
+	updated, _ = m.Update(fsEventMsg{})
+	m = updated.(Model)
+	assert.Greater(t, m.pollGen, gen1, "fsEventMsg should bump pollGen again")
+}
+
+func TestRefreshResult_SkipsNextTickWhenUnfocused(t *testing.T) {
 	m := makeModel("a.go")
 	m.polling = true
 	m.focused = false
 	m.lastFingerprint = "M a.go\n"
 
-	updated, cmd := m.Update(pollResultMsg{fingerprint: "M a.go\n"})
+	updated, cmd := m.Update(refreshResultMsg{fingerprint: "M a.go\n", duration: 50 * time.Millisecond})
 	m = updated.(Model)
 	assert.False(t, m.polling, "polling flag should be cleared")
 	assert.Nil(t, cmd, "should not schedule next tick when unfocused")
 }
 
-func TestPollResult_ClearsPollingFlag(t *testing.T) {
+func TestRefreshResult_ClearsPollingFlag(t *testing.T) {
 	m := makeModel("a.go")
 	m.polling = true
 	m.lastFingerprint = "M a.go\n"
 
-	updated, _ := m.Update(pollResultMsg{fingerprint: "M a.go\n"})
+	updated, _ := m.Update(refreshResultMsg{fingerprint: "M a.go\n", duration: 50 * time.Millisecond})
 	m = updated.(Model)
 	assert.False(t, m.polling, "polling flag should be cleared after result")
 }
 
-func TestPollInterval_IsAtLeast30Seconds(t *testing.T) {
-	assert.GreaterOrEqual(t, pollInterval, 30*time.Second,
-		"poll interval must be >= 30s to avoid I/O contention (see #129)")
+func TestShortDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "0µs"},
+		{500 * time.Microsecond, "500µs"},
+		{45 * time.Millisecond, "45ms"},
+		{2300 * time.Millisecond, "2.3s"},
+		{125 * time.Second, "2m05s"},
+		{-time.Second, "0µs"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, shortDuration(tc.in), "shortDuration(%s)", tc.in)
+	}
+}
+
+func TestAgoAndDur_ZeroStartReturnsDash(t *testing.T) {
+	assert.Equal(t, "—", agoAndDur(time.Time{}, 0, time.Now()))
+}
+
+func TestUntilOrDash(t *testing.T) {
+	now := time.Now()
+	assert.Equal(t, "—", untilOrDash(time.Time{}, now))
+	assert.Equal(t, "now", untilOrDash(now.Add(-1*time.Second), now))
+	assert.Equal(t, "1.5s", untilOrDash(now.Add(1500*time.Millisecond), now))
+}
+
+func TestDebugTickMsg_OnlyReschedulesInDebugMode(t *testing.T) {
+	m := makeModel("a.go")
+	m.debug = false
+
+	_, cmd := m.Update(debugTickMsg{})
+	assert.Nil(t, cmd, "debugTickMsg outside --debug should be a no-op")
+
+	m.debug = true
+	_, cmd = m.Update(debugTickMsg{})
+	assert.NotNil(t, cmd, "debugTickMsg in --debug should reschedule")
+}
+
+func TestRefreshResult_RecordsDurationForBackoff(t *testing.T) {
+	m := makeModel("a.go")
+	m.polling = true
+
+	updated, _ := m.Update(refreshResultMsg{fingerprint: "x", duration: 7 * time.Second})
+	m = updated.(Model)
+	assert.Equal(t, 7*time.Second, m.lastPollDuration,
+		"lastPollDuration drives the next NextDelay() — slow polls must record their duration")
 }
 
 // --- File review mode tests ---

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -101,6 +101,10 @@ var (
 	// Status bar
 	statusBarStyle lipgloss.Style
 
+	// --debug mode strip above the status bar
+	devLabelStyle lipgloss.Style
+	devValueStyle lipgloss.Style
+
 	// Help styles
 	helpKeyStyle   lipgloss.Style
 	helpTextStyle  lipgloss.Style
@@ -195,6 +199,9 @@ func applyTheme(p themeColors) {
 
 	statusBarStyle = lipgloss.NewStyle().Foreground(p.dim)
 
+	devLabelStyle = lipgloss.NewStyle().Foreground(p.yellow).Bold(true)
+	devValueStyle = lipgloss.NewStyle().Foreground(p.dim)
+
 	helpKeyStyle = lipgloss.NewStyle().Bold(true).Foreground(p.cyan)
 	helpTextStyle = lipgloss.NewStyle().Foreground(p.white)
 	helpGroupStyle = lipgloss.NewStyle().Bold(true).Foreground(p.white)
@@ -254,6 +261,8 @@ func applyNoColor() {
 	modeInactiveStyle = lipgloss.NewStyle()
 	modeDisabledStyle = lipgloss.NewStyle().Faint(true).Strikethrough(true)
 	statusBarStyle = lipgloss.NewStyle()
+	devLabelStyle = lipgloss.NewStyle().Bold(true)
+	devValueStyle = lipgloss.NewStyle()
 	helpKeyStyle = lipgloss.NewStyle().Bold(true)
 	helpTextStyle = lipgloss.NewStyle()
 	helpGroupStyle = lipgloss.NewStyle().Bold(true)

--- a/main.go
+++ b/main.go
@@ -10,11 +10,13 @@ import (
 	"strings"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"charm.land/lipgloss/v2"
 	"github.com/justincampbell/revise/internal/comments"
 	"github.com/justincampbell/revise/internal/devwatch"
+	"github.com/justincampbell/revise/internal/fswatch"
 	"github.com/justincampbell/revise/internal/git"
 	"github.com/justincampbell/revise/internal/ui"
 	"github.com/justincampbell/revise/internal/update"
@@ -44,6 +46,8 @@ func main() {
 	flag.BoolVar(versionFlag, "v", false, "Show version (shorthand)")
 	themeFlag := flag.String("theme", "auto", "Color theme: auto, auto-daltonized, charmtone-dark, charmtone-dark-daltonized, charmtone-light, charmtone-light-daltonized, github-dark, github-dark-daltonized, github-light, github-light-daltonized")
 	devFlag := flag.Bool("dev", false, "Auto-restart when the binary is replaced (for local development)")
+	debugFlag := flag.Bool("debug", false, "Show a refresh-debug strip with live timings above the status bar")
+	noWatchFlag := flag.Bool("no-watch", false, "Disable fsnotify-based refresh; auto-refresh runs on a timer only")
 	flag.Parse()
 
 	if *helpFlag {
@@ -141,7 +145,20 @@ func main() {
 		storePath = comments.StorePath(repoRoot, branch)
 	}
 
-	m := ui.NewWithStorePath(diff, onDefaultBranch, storePath, version)
+	m := ui.NewWithStorePath(diff, onDefaultBranch, storePath, version).
+		WithDebug(*debugFlag)
+
+	// Attach an fsnotify-based watcher so file edits wake the refresh
+	// loop directly (instead of waiting for the next scheduled tick).
+	// Soft-fail to timer-only on any error — fsnotify can fail on
+	// network filesystems, FD-limited environments, or unusual repos.
+	if !*noWatchFlag && os.Getenv("REVISE_NO_WATCH") == "" {
+		if watcher, werr := startWatcher(); werr == nil {
+			defer watcher.Close() //nolint:errcheck // best-effort on shutdown
+			m = m.WithFSWatcher(watcher)
+		}
+	}
+
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion(), tea.WithReportFocus(), tea.WithOutput(ttyOut))
 
 	finalModel, err := runProgram(p, *devFlag)
@@ -174,6 +191,21 @@ func runFileReview(filePath string, outputPath string, devMode bool) {
 	if fm, ok := finalModel.(ui.Model); ok {
 		writeComments(fm, outputPath)
 	}
+}
+
+// startWatcher initializes the fswatch.Watcher pointed at the current
+// repo's working tree and git directory. Returns an error if either
+// path lookup or fsnotify init fails — callers fall back to timer-only.
+func startWatcher() (*fswatch.Watcher, error) {
+	workTree, err := git.RepoRoot()
+	if err != nil {
+		return nil, err
+	}
+	gitDir, err := git.GitDir()
+	if err != nil {
+		return nil, err
+	}
+	return fswatch.New(workTree, gitDir, 100*time.Millisecond)
 }
 
 // runProgram runs a Bubbletea program. When devMode is true, it polls the
@@ -328,6 +360,8 @@ Flags:
                           github-light, github-light-daltonized
   --output <file>       Write comments to file on exit
   --dev                 Auto-restart when the binary is replaced (development)
+  --debug               Show a refresh-debug strip with live timings above the status bar
+  --no-watch            Disable fsnotify-based refresh (timer-only auto-refresh)
 
 Commands:
   diff            Print unified diff (no TUI)


### PR DESCRIPTION
## Summary

- Replace fixed-30s polling with three cooperating modules: `internal/refresh` (adaptive cadence policy), `internal/fswatch` (fsnotify wakeups, gitignore-correct via `git ls-files`-derived dirs + dynamic dir watching), and a `requestRefresh()` funnel in `internal/ui` with a generation counter that invalidates stale ticks
- Cadence self-throttles: `next = clamp(Min, Multiplier × lastDuration, Max)`, defaults `{2s, 30s, 5}` — solo + fast repo polls every 2s, 10–20 instances on shared-repo worktrees back off automatically when `git status` slows down
- `FocusMsg` and fsnotify events both fire an immediate (debounced) refresh; the periodic timer is a fallback
- New `--debug` flag adds a one-line strip above the status bar with live timings (focus state, fsnotify on/off, polling status, "Xs ago" for last fingerprint check / diff reload with durations, countdown to next tick, gen counter). Independent of `--dev`
- `--no-watch` / `REVISE_NO_WATCH=1` opts out of fsnotify; soft-fall-back if `fsnotify.NewWatcher` fails
- Adds dependency: `github.com/fsnotify/fsnotify v1.9.0`

Closes #144. Supersedes #166.

## Test plan

- [x] `make` passes (lint + test)
- [x] New tests: refresh policy table tests, fswatch integration tests (real git tempdirs, including dynamic dir watching), model_test gen-counter / focus-fires-immediate / fsEvent / blur-stops-rescheduling
- [x] `make install`
- [x] Manual: edit a tracked file in another tmux pane while revise is focused → refresh within ~policy.Min
- [x] Manual: blur revise, edit in another pane, refocus → immediate refresh
- [x] Manual: `mkdir new-feature && touch new-feature/foo.go` → fires refresh (dynamic dir watching)
- [x] Manual: `--debug` strip displays correctly; `next` shows `polling…` / `blurred` / countdown by state
- [ ] Stress: 10 instances across worktrees, observe `git status` ambient load stays bounded (cadence backs off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filesystem changes now automatically trigger status refresh for faster updates
  * Adaptive refresh timing adjusts based on git command performance metrics
  * New `--debug` flag displays live refresh state and performance timings above the status bar
  * New `--no-watch` flag to disable filesystem watching and revert to timer-only refresh

* **Chores**
  * Updated documentation; added filesystem watching dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->