### PR TITLE
Add --mode and --hunks flags to revise diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `setup-cache` subcommand to enable git's `core.untrackedCache` for faster refreshes; a startup tip surfaces in the status bar when the cache is disabled but the filesystem supports it (#160)
 - Horizontal scroll in the diff view via →/← (or h/l) and mouse wheel left/right (#121)
 - `revise diff --mode=<branch|staged|staged-only|unstaged>` selects which diff to print non-interactively (default: auto-detect, same as launching the TUI). Useful for scripting and debugging (#177)
+- `revise diff --hunks` prints TUI-style output — file path header, `[source]` tag with function context, and a line-number gutter — instead of unified diff format. Built on shared formatters (`FormatGutter`, `HunkHeaderText`) the TUI also uses (#177)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `--dev` flag auto-restarts the running TUI when the binary is replaced (e.g. by `make install`), preserving argv and env (#160)
 - `setup-cache` subcommand to enable git's `core.untrackedCache` for faster refreshes; a startup tip surfaces in the status bar when the cache is disabled but the filesystem supports it (#160)
 - Horizontal scroll in the diff view via →/← (or h/l) and mouse wheel left/right (#121)
+- `revise diff --mode=<branch|staged|staged-only|unstaged>` selects which diff to print non-interactively (default: auto-detect, same as launching the TUI). Useful for scripting and debugging (#177)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `--dev` flag auto-restarts the running TUI when the binary is replaced (e.g. by `make install`), preserving argv and env (#160)
 - `setup-cache` subcommand to enable git's `core.untrackedCache` for faster refreshes; a startup tip surfaces in the status bar when the cache is disabled but the filesystem supports it (#160)
 - Horizontal scroll in the diff view via →/← (or h/l) and mouse wheel left/right (#121)
-- `revise diff --mode=<branch|staged|staged-only|unstaged>` selects which diff to print non-interactively (default: auto-detect, same as launching the TUI). Useful for scripting and debugging (#177)
-- `revise diff --hunks` prints TUI-style output — file path header, `[source]` tag with function context, and a line-number gutter — instead of unified diff format. Built on shared formatters (`FormatGutter`, `HunkHeaderText`) the TUI also uses (#177)
+- `revise diff --mode=<branch|staged|staged-only|unstaged>` selects which diff to print non-interactively (default: auto-detect, same as launching the TUI) (#177)
+- `revise diff --hunks` prints TUI-style output — file path header, `[source]` tag with function context, and a line-number gutter — instead of unified diff format (#177)
 
 ### Changed
 

--- a/internal/git/format.go
+++ b/internal/git/format.go
@@ -14,6 +14,104 @@ func Format(d *Diff) string {
 	return b.String()
 }
 
+// FormatHunks renders a Diff in the same shape the TUI shows on screen —
+// file path header, hunk header with source label + function context, then
+// each line prefixed by a 6-char line-number gutter and a +/-/space marker.
+// No ANSI colors. Useful for non-interactive debugging via `revise diff --hunks`.
+func FormatHunks(d *Diff) string {
+	var b strings.Builder
+	for i, f := range d.Files {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		formatHunksFile(&b, f)
+	}
+	return b.String()
+}
+
+func formatHunksFile(b *strings.Builder, f FileDiff) {
+	fmt.Fprintf(b, "%s\n", f.Path)
+	if f.IsBinary {
+		b.WriteString("  Binary file — cannot display diff\n")
+		return
+	}
+	for _, h := range f.Hunks {
+		if header := HunkHeaderText(h); header != "" {
+			fmt.Fprintf(b, "%s\n", header)
+		}
+		for _, l := range h.Lines {
+			marker := " "
+			switch l.Type {
+			case LineAdded:
+				marker = "+"
+			case LineRemoved:
+				marker = "-"
+			}
+			fmt.Fprintf(b, "%s%s %s\n", FormatGutter(l), marker, l.Content)
+		}
+	}
+}
+
+// FormatGutter returns the 6-char line-number gutter shown next to each diff
+// line: 5-char right-aligned number + 1 space, or 6 spaces for non-content
+// lines (hunk headers, blank separators). Removed lines use OldNum; added and
+// context lines use NewNum.
+func FormatGutter(l Line) string {
+	n := l.NewNum
+	if l.Type == LineRemoved {
+		n = l.OldNum
+	}
+	switch l.Type {
+	case LineAdded, LineRemoved, LineContext:
+		return fmt.Sprintf("%5d ", n)
+	}
+	return "      "
+}
+
+// HunkHeaderText composes the hunk header the way it appears in the TUI:
+// optional `[source]` tag (branch/staged/unstaged) + the function-context
+// trailer from the `@@ -x,y +a,b @@ context` line. Returns "" when neither
+// is available (e.g. file review mode).
+func HunkHeaderText(h Hunk) string {
+	label := HunkSourceLabel(h.Source)
+	context := HunkContextText(h.Header)
+	switch {
+	case label == "" && context == "":
+		return ""
+	case context == "":
+		return "[" + label + "]"
+	case label == "":
+		return context
+	default:
+		return "[" + label + "] " + context
+	}
+}
+
+// HunkSourceLabel returns the lowercase label for a HunkSource ("branch",
+// "staged", "unstaged"), or "" for the zero value.
+func HunkSourceLabel(s HunkSource) string {
+	switch s {
+	case SourceBranch:
+		return "branch"
+	case SourceStaged:
+		return "staged"
+	case SourceUnstaged:
+		return "unstaged"
+	}
+	return ""
+}
+
+// HunkContextText extracts the trailing context from a unified-diff hunk
+// header (`@@ -x,y +a,b @@ trailing context`). Returns "" if the header has
+// no trailing context.
+func HunkContextText(header string) string {
+	parts := strings.SplitN(header, "@@", 3)
+	if len(parts) < 3 {
+		return strings.TrimSpace(header)
+	}
+	return strings.TrimSpace(parts[2])
+}
+
 func formatFile(b *strings.Builder, f FileDiff) {
 	path := f.Path
 	oldPath := f.OldPath

--- a/internal/git/format_test.go
+++ b/internal/git/format_test.go
@@ -93,3 +93,99 @@ func TestFormat_RenamedFile(t *testing.T) {
 	assert.Contains(t, got, "rename from old_name.go")
 	assert.Contains(t, got, "rename to new_name.go")
 }
+
+func TestFormatGutter_Added(t *testing.T) {
+	l := Line{Type: LineAdded, NewNum: 42}
+	assert.Equal(t, "   42 ", FormatGutter(l))
+}
+
+func TestFormatGutter_Removed(t *testing.T) {
+	l := Line{Type: LineRemoved, OldNum: 7}
+	assert.Equal(t, "    7 ", FormatGutter(l))
+}
+
+func TestFormatGutter_Context(t *testing.T) {
+	l := Line{Type: LineContext, OldNum: 3, NewNum: 5}
+	assert.Equal(t, "    5 ", FormatGutter(l))
+}
+
+func TestHunkContextText_ExtractsTrailingContext(t *testing.T) {
+	got := HunkContextText("@@ -10,6 +12,7 @@ func renderStatusBar() string {")
+	assert.Equal(t, "func renderStatusBar() string {", got)
+}
+
+func TestHunkContextText_NoAtAt(t *testing.T) {
+	got := HunkContextText("some random text")
+	assert.Equal(t, "some random text", got)
+}
+
+func TestHunkContextText_EmptyContext(t *testing.T) {
+	got := HunkContextText("@@ -1,1 +1,1 @@")
+	assert.Equal(t, "", got)
+}
+
+func TestHunkSourceLabel(t *testing.T) {
+	assert.Equal(t, "branch", HunkSourceLabel(SourceBranch))
+	assert.Equal(t, "staged", HunkSourceLabel(SourceStaged))
+	assert.Equal(t, "unstaged", HunkSourceLabel(SourceUnstaged))
+	assert.Equal(t, "", HunkSourceLabel(""))
+}
+
+func TestHunkHeaderText(t *testing.T) {
+	tests := []struct {
+		name string
+		hunk Hunk
+		want string
+	}{
+		{"no source no context", Hunk{Header: "@@ -1,1 +1,1 @@"}, ""},
+		{"source only", Hunk{Header: "@@ -1,1 +1,1 @@", Source: SourceStaged}, "[staged]"},
+		{"context only", Hunk{Header: "@@ -1,1 +1,1 @@ funcName()"}, "funcName()"},
+		{"source + context", Hunk{Header: "@@ -1,1 +1,1 @@ funcName()", Source: SourceBranch}, "[branch] funcName()"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HunkHeaderText(tt.hunk))
+		})
+	}
+}
+
+func TestFormatHunks_RendersFilePathAndGutter(t *testing.T) {
+	d := &Diff{
+		Files: []FileDiff{{
+			Path:   "hello.go",
+			Status: StatusModified,
+			Hunks: []Hunk{{
+				OldStart: 10, OldCount: 2, NewStart: 10, NewCount: 3,
+				Header: "@@ -10,2 +10,3 @@ func main()",
+				Source: SourceUnstaged,
+				Lines: []Line{
+					{Type: LineContext, Content: "x := 1", OldNum: 10, NewNum: 10},
+					{Type: LineRemoved, Content: "old", OldNum: 11},
+					{Type: LineAdded, Content: "new", NewNum: 11},
+					{Type: LineAdded, Content: "extra", NewNum: 12},
+				},
+			}},
+		}},
+	}
+
+	got := FormatHunks(d)
+	assert.Contains(t, got, "hello.go\n")
+	assert.Contains(t, got, "[unstaged] func main()")
+	assert.Contains(t, got, "   10   x := 1")
+	assert.Contains(t, got, "   11 - old")
+	assert.Contains(t, got, "   11 + new")
+	assert.Contains(t, got, "   12 + extra")
+}
+
+func TestFormatHunks_BinaryFile(t *testing.T) {
+	d := &Diff{
+		Files: []FileDiff{{
+			Path:     "logo.png",
+			Status:   StatusModified,
+			IsBinary: true,
+		}},
+	}
+	got := FormatHunks(d)
+	assert.Contains(t, got, "logo.png")
+	assert.Contains(t, got, "Binary file")
+}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -416,7 +416,7 @@ func (m diffViewModel) clickToAbsIdx(clickY int) int {
 }
 
 func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p themeColors, indentSize int) string {
-	gutter := formatGutter(l)
+	gutter := git.FormatGutter(l)
 	if marked {
 		content := l.Content
 		// Pad content to fill the available width so background covers the line.
@@ -455,38 +455,23 @@ func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p t
 	return l.Content
 }
 
-func formatGutter(l git.Line) string {
-	n := l.NewNum
-	if l.Type == git.LineRemoved {
-		n = l.OldNum
-	}
-	switch l.Type {
-	case git.LineAdded, git.LineRemoved, git.LineContext:
-		return fmt.Sprintf("%5d ", n)
-	}
-	return "      "
-}
-
 func renderHunkHeader(h git.Hunk) string {
-	header := hunkContext(h.Header)
-
-	style := hunkStyle
-	var label string
-	switch h.Source {
-	case git.SourceBranch:
-		style = hunkBranchStyle
-		label = "branch"
-	case git.SourceStaged:
-		style = hunkStagedStyle
-		label = "staged"
-	case git.SourceUnstaged:
-		style = hunkUnstagedStyle
-		label = "unstaged"
-	}
+	header := git.HunkContextText(h.Header)
+	label := git.HunkSourceLabel(h.Source)
 
 	// No source and no header context — nothing to show (e.g. file review mode).
 	if label == "" && header == "" {
 		return ""
+	}
+
+	style := hunkStyle
+	switch h.Source {
+	case git.SourceBranch:
+		style = hunkBranchStyle
+	case git.SourceStaged:
+		style = hunkStagedStyle
+	case git.SourceUnstaged:
+		style = hunkUnstagedStyle
 	}
 
 	tag := hunkSourceTagStyle.Render("[" + label + "]")
@@ -497,14 +482,6 @@ func renderHunkHeader(h git.Hunk) string {
 		return style.Render(header)
 	}
 	return tag + " " + style.Render(header)
-}
-
-func hunkContext(header string) string {
-	parts := strings.SplitN(header, "@@", 3)
-	if len(parts) < 3 {
-		return strings.TrimSpace(header)
-	}
-	return strings.TrimSpace(parts[2])
 }
 
 // linePrefix returns the 1-character indicator for a display line — cursor

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -126,21 +126,6 @@ func TestDiffViewViewHeight_MinimumOne(t *testing.T) {
 	assert.Equal(t, 1, m.viewHeight())
 }
 
-func TestFormatGutter_Added(t *testing.T) {
-	l := git.Line{Type: git.LineAdded, NewNum: 42}
-	assert.Equal(t, "   42 ", formatGutter(l))
-}
-
-func TestFormatGutter_Removed(t *testing.T) {
-	l := git.Line{Type: git.LineRemoved, OldNum: 7}
-	assert.Equal(t, "    7 ", formatGutter(l))
-}
-
-func TestFormatGutter_Context(t *testing.T) {
-	l := git.Line{Type: git.LineContext, OldNum: 3, NewNum: 5}
-	assert.Equal(t, "    5 ", formatGutter(l))
-}
-
 func TestDiffViewCursorMovesDown(t *testing.T) {
 	m := makeDiffViewModel(10, 6) // viewHeight = 6
 	m.moveCursorDown(1)
@@ -397,20 +382,6 @@ func TestRenderHunkHeader_EmptyContext_StillShowsTag(t *testing.T) {
 	assert.Contains(t, got, "[staged]")
 }
 
-func TestHunkContext_ExtractsTrailingContext(t *testing.T) {
-	got := hunkContext("@@ -10,6 +12,7 @@ func renderStatusBar() string {")
-	assert.Equal(t, "func renderStatusBar() string {", got)
-}
-
-func TestHunkContext_NoAtAt(t *testing.T) {
-	got := hunkContext("some random text")
-	assert.Equal(t, "some random text", got)
-}
-
-func TestHunkContext_EmptyContext(t *testing.T) {
-	got := hunkContext("@@ -1,1 +1,1 @@")
-	assert.Equal(t, "", got)
-}
 
 func TestDiffView_TitleInBorder(t *testing.T) {
 	m := newDiffViewModel()

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 
 	// Subcommands that require a git repo.
 	if len(args) > 0 && args[0] == "diff" {
-		runDiff()
+		runDiff(args[1:])
 		return
 	}
 	if len(args) > 0 && args[0] == "setup-cache" {
@@ -292,14 +292,37 @@ func buildFileDiff(filePath string) (*git.Diff, error) {
 	}, nil
 }
 
-func runDiff() {
-	diff, err := git.GetDiff()
+func runDiff(args []string) {
+	fs := flag.NewFlagSet("diff", flag.ExitOnError)
+	modeFlag := fs.String("mode", "", "Diff mode: branch, staged, staged-only, unstaged (default: auto-detect)")
+	_ = fs.Parse(args)
+
+	diff, err := loadDiffForMode(*modeFlag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
 	fmt.Print(git.Format(diff))
+}
+
+// loadDiffForMode returns a *git.Diff for the given mode string. An empty
+// mode auto-detects (branch on feature branches, working-tree on default).
+func loadDiffForMode(mode string) (*git.Diff, error) {
+	switch mode {
+	case "":
+		return git.GetDiff()
+	case "branch":
+		return git.BranchDiff(git.DefaultContextLines)
+	case "staged":
+		return git.WorkingTreeDiff(git.DefaultContextLines)
+	case "staged-only":
+		return git.StagedOnlyDiff(git.DefaultContextLines)
+	case "unstaged":
+		return git.UnstagedOnlyDiff(git.DefaultContextLines)
+	default:
+		return nil, fmt.Errorf("unknown --mode %q (valid: branch, staged, staged-only, unstaged)", mode)
+	}
 }
 
 func runSetupCache() {
@@ -364,7 +387,9 @@ Flags:
   --no-watch            Disable fsnotify-based refresh (timer-only auto-refresh)
 
 Commands:
-  diff            Print unified diff (no TUI)
+  diff [--mode]   Print unified diff (no TUI)
+                    --mode branch | staged | staged-only | unstaged
+                    (default: auto-detect — same as launching the TUI)
   setup-cache     Enable git's core.untrackedCache for faster refreshes
   styles          Show file status color matrix
   update [--pre]  Update to the latest version

--- a/main.go
+++ b/main.go
@@ -295,6 +295,7 @@ func buildFileDiff(filePath string) (*git.Diff, error) {
 func runDiff(args []string) {
 	fs := flag.NewFlagSet("diff", flag.ExitOnError)
 	modeFlag := fs.String("mode", "", "Diff mode: branch, staged, staged-only, unstaged (default: auto-detect)")
+	hunksFlag := fs.Bool("hunks", false, "Print TUI-style hunks (file path header, line-number gutter) instead of unified diff")
 	_ = fs.Parse(args)
 
 	diff, err := loadDiffForMode(*modeFlag)
@@ -303,6 +304,10 @@ func runDiff(args []string) {
 		os.Exit(1)
 	}
 
+	if *hunksFlag {
+		fmt.Print(git.FormatHunks(diff))
+		return
+	}
 	fmt.Print(git.Format(diff))
 }
 
@@ -387,9 +392,11 @@ Flags:
   --no-watch            Disable fsnotify-based refresh (timer-only auto-refresh)
 
 Commands:
-  diff [--mode]   Print unified diff (no TUI)
+  diff [flags]    Print diff (no TUI)
                     --mode branch | staged | staged-only | unstaged
-                    (default: auto-detect — same as launching the TUI)
+                      (default: auto-detect — same as launching the TUI)
+                    --hunks  TUI-style output (path header, line-number gutter)
+                      instead of unified diff format
   setup-cache     Enable git's core.untrackedCache for faster refreshes
   styles          Show file status color matrix
   update [--pre]  Update to the latest version

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadDiffForMode_UnknownMode(t *testing.T) {
+	_, err := loadDiffForMode("bogus")
+	if err == nil {
+		t.Fatal("expected error for unknown mode")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "bogus") {
+		t.Errorf("error should mention the bad mode value, got: %s", msg)
+	}
+	for _, valid := range []string{"branch", "staged", "staged-only", "unstaged"} {
+		if !strings.Contains(msg, valid) {
+			t.Errorf("error should list %q as a valid mode, got: %s", valid, msg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds two flags to the existing `revise diff` subcommand for non-interactive use.

**`--mode`** picks which diff view to dump (matches the TUI's mode cycle):

```
revise diff                       # auto-detect (same as the TUI default)
revise diff --mode=branch         # committed + working tree
revise diff --mode=staged         # staged + unstaged + untracked
revise diff --mode=staged-only    # staged only
revise diff --mode=unstaged       # unstaged + untracked
```

Unknown modes get a friendly error listing the valid choices.

**`--hunks`** prints output that mirrors the TUI rendering — file path header, `[source]` tag with function context, and a 6-char line-number gutter — instead of the standard unified diff format:

```
main.go
[branch] func main() {
  110
  111   	// Subcommands that require a git repo.
  112   	if len(args) > 0 && args[0] == "diff" {
  113 - 		runDiff()
  113 + 		runDiff(args[1:])
  114   		return
  115   	}
```

The shared formatters (`FormatGutter`, `HunkHeaderText`, `HunkSourceLabel`, `HunkContextText`) were lifted from `internal/ui/diffview.go` into `internal/git/format.go` so the TUI's `renderHunkHeader` and `renderDiffLine` both use them — no duplication.

Closes #177

## Test plan

- [x] `make` (lint + tests) green; existing TUI gutter/header tests moved to `internal/git/format_test.go` and still pass
- [x] `make install` and verified each mode against this very repo's working tree:
  - default = branch (90 lines on a feature branch with no commits and dirty tree)
  - staged-only = 64 lines after `git add main.go`, unstaged = 26, staged = 90 (matches partition)
  - `--mode=bogus` errors with the expected message
- [x] `revise diff --hunks` produces TUI-style output with file path, `[branch]` label + function context, and `5d ` gutter
- [ ] One reviewer pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--mode` flag to control diff selection mode with auto-detection (supports branch, staged, unstaged, staged-only).
  * Added `--hunks` flag to display diffs in TUI-style format featuring file headers, function context annotations, and line-number gutters.

* **Tests**
  * Added comprehensive unit tests for new diff formatting functions and mode validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->