### PR TITLE
Cap fsnotify watches to prevent fd exhaustion in large repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fswatch now installs a watch on newly-created directories on the fly, so `mkdir new-feature && touch new-feature/foo.go` triggers a refresh immediately instead of waiting for the next periodic poll (#144)
 - Auto-refresh now wakes on file changes (via fsnotify) and on terminal focus, instead of waiting up to 30s for the next polling tick. Cadence is adaptive — it self-throttles based on how long the last `git status` took, so running 10-20 revise instances on shared-repo worktrees no longer piles up I/O. Pass `--no-watch` (or set `REVISE_NO_WATCH=1`) to disable the fsnotify path and fall back to timer-only refreshes (#144)
 - Startup no longer runs `git update-index --test-untracked-cache`, which created `mtime-test-XXXXXX/` directories in the working tree (and left them behind if the process exited before cleanup). The startup tip now fires on any repo with `core.untrackedCache` disabled; the FS test still runs on demand inside `revise setup-cache` (#178)
+- fswatch now refuses to install when a repo has more than 500 unique tracked directories, falling back to timer-only refresh. Each fsnotify watch holds an fd on macOS (kqueue) and Linux (inotify); large repos × concurrent revise instances could exhaust the system fd limit and crash startup with `too many open files in system` (#183)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fswatch now installs a watch on newly-created directories on the fly, so `mkdir new-feature && touch new-feature/foo.go` triggers a refresh immediately instead of waiting for the next periodic poll (#144)
 - Auto-refresh now wakes on file changes (via fsnotify) and on terminal focus, instead of waiting up to 30s for the next polling tick. Cadence is adaptive — it self-throttles based on how long the last `git status` took, so running 10-20 revise instances on shared-repo worktrees no longer piles up I/O. Pass `--no-watch` (or set `REVISE_NO_WATCH=1`) to disable the fsnotify path and fall back to timer-only refreshes (#144)
 - Startup no longer runs `git update-index --test-untracked-cache`, which created `mtime-test-XXXXXX/` directories in the working tree (and left them behind if the process exited before cleanup). The startup tip now fires on any repo with `core.untrackedCache` disabled; the FS test still runs on demand inside `revise setup-cache` (#178)
-- fswatch now refuses to install when a repo has more than 500 unique tracked directories, falling back to timer-only refresh. Each fsnotify watch holds an fd on macOS (kqueue) and Linux (inotify); large repos × concurrent revise instances could exhaust the system fd limit and crash startup with `too many open files in system` (#183)
+- fswatch now caps fsnotify watches at 500 — refuses to install when a repo has more tracked directories at startup, and refuses runtime adds (e.g. directories created by `npm install`) once the cap is hit. Without the cap, large repos × concurrent revise instances could exhaust the system fd limit and crash startup with `too many open files in system` (#183)
 
 ### Added
 

--- a/internal/fswatch/watcher.go
+++ b/internal/fswatch/watcher.go
@@ -12,6 +12,7 @@ package fswatch
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +22,15 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 )
+
+// MaxWatches caps the number of fsnotify watches installed by New.
+// Each watch holds an fd on macOS (kqueue) and Linux (inotify), so
+// large repos × many concurrent revise instances can exhaust the
+// system fd limit (kern.maxfiles on macOS). When the unique tracked-
+// directory count would exceed this cap, New returns an error so the
+// caller can fall back to timer-only refresh. Exported as a var so
+// tests can override it.
+var MaxWatches = 500
 
 // Event is a wakeup signal — it carries no data. The caller re-checks
 // state via whatever primitive is appropriate (e.g. git.StatusFingerprint).
@@ -102,9 +112,11 @@ func (w *Watcher) Close() error {
 }
 
 // addTrackedDirs adds fsnotify watches on the unique parent directories
-// of files reported by `git ls-files`. Failures on individual Adds are
-// non-fatal — a missing watch just means missed events for that dir,
-// not a broken watcher.
+// of files reported by `git ls-files`. The unique set is computed before
+// any Add calls so we can refuse cleanly when the count would exceed
+// MaxWatches — adding partial watches and then bailing would leak fds.
+// Failures on individual Adds are non-fatal — a missing watch just means
+// missed events for that dir, not a broken watcher.
 func (w *Watcher) addTrackedDirs() error {
 	cmd := exec.Command("git", "-C", w.workTree, "ls-files")
 	out, err := cmd.Output()
@@ -115,17 +127,20 @@ func (w *Watcher) addTrackedDirs() error {
 	seen := make(map[string]struct{})
 	// Always watch the working tree root so top-level files are covered.
 	seen[w.workTree] = struct{}{}
-	_ = w.fsn.Add(w.workTree)
 
 	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
 		if line == "" {
 			continue
 		}
 		dir := filepath.Join(w.workTree, filepath.Dir(line))
-		if _, ok := seen[dir]; ok {
-			continue
-		}
 		seen[dir] = struct{}{}
+	}
+
+	if len(seen) > MaxWatches {
+		return fmt.Errorf("fswatch: %d tracked dirs exceeds watch cap of %d", len(seen), MaxWatches)
+	}
+
+	for dir := range seen {
 		_ = w.fsn.Add(dir)
 	}
 	return nil

--- a/internal/fswatch/watcher.go
+++ b/internal/fswatch/watcher.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -46,8 +47,15 @@ type Watcher struct {
 
 	out chan Event
 
+	// watchCount tracks the number of installed fsnotify watches so
+	// dynamic adds in maybeWatchNewDir don't blow past MaxWatches at
+	// runtime (e.g. an `npm install` creating thousands of dirs).
+	// Atomic so tests can read it without racing the run goroutine.
+	watchCount atomic.Int64
+
 	closeOnce sync.Once
 	done      chan struct{}
+	wg        sync.WaitGroup
 }
 
 // New starts a watcher over the working tree and git directory.
@@ -86,12 +94,14 @@ func New(workTree, gitDir string, coalesce time.Duration) (*Watcher, error) {
 		_ = fsn.Close()
 		return nil, err
 	}
+	w.watchCount.Store(1)
 
 	if err := w.addTrackedDirs(); err != nil {
 		_ = fsn.Close()
 		return nil, err
 	}
 
+	w.wg.Add(1)
 	go w.run()
 	return w, nil
 }
@@ -100,13 +110,14 @@ func New(workTree, gitDir string, coalesce time.Duration) (*Watcher, error) {
 // channel is closed when the Watcher is Closed.
 func (w *Watcher) Events() <-chan Event { return w.out }
 
-// Close stops the watcher and releases its resources. Safe to call
-// multiple times.
+// Close stops the watcher, waits for the run goroutine to exit, and
+// releases resources. Safe to call multiple times.
 func (w *Watcher) Close() error {
 	var err error
 	w.closeOnce.Do(func() {
 		close(w.done)
 		err = w.fsn.Close()
+		w.wg.Wait()
 	})
 	return err
 }
@@ -141,7 +152,9 @@ func (w *Watcher) addTrackedDirs() error {
 	}
 
 	for dir := range seen {
-		_ = w.fsn.Add(dir)
+		if err := w.fsn.Add(dir); err == nil {
+			w.watchCount.Add(1)
+		}
 	}
 	return nil
 }
@@ -149,6 +162,7 @@ func (w *Watcher) addTrackedDirs() error {
 // run is the watcher goroutine: it filters incoming fsnotify events,
 // coalesces bursts within w.coalesce, and emits one Event per burst.
 func (w *Watcher) run() {
+	defer w.wg.Done()
 	defer close(w.out)
 
 	for {
@@ -213,17 +227,24 @@ func (w *Watcher) drainBurst() {
 //
 // We don't filter against gitignore here; gitignored content (e.g. an
 // errant `node_modules`) won't change `git status` output, so the
-// fingerprint check stays stable and no diff reload happens. The cost
-// is a few extra fsnotify watches.
+// fingerprint check stays stable and no diff reload happens. We do
+// enforce MaxWatches though — a runaway burst of dir creation (npm
+// install dropping thousands of node_modules subdirs) would otherwise
+// reintroduce the fd-exhaustion this cap exists to prevent.
 func (w *Watcher) maybeWatchNewDir(ev fsnotify.Event) {
 	if ev.Op&fsnotify.Create == 0 {
+		return
+	}
+	if w.watchCount.Load() >= int64(MaxWatches) {
 		return
 	}
 	info, err := os.Stat(ev.Name)
 	if err != nil || !info.IsDir() {
 		return
 	}
-	_ = w.fsn.Add(ev.Name)
+	if err := w.fsn.Add(ev.Name); err == nil {
+		w.watchCount.Add(1)
+	}
 }
 
 // relevant reports whether an fsnotify event should trigger a refresh.

--- a/internal/fswatch/watcher_test.go
+++ b/internal/fswatch/watcher_test.go
@@ -235,6 +235,32 @@ func TestWatcher_RefusesAboveWatchCap(t *testing.T) {
 	assert.Contains(t, err.Error(), "watch cap")
 }
 
+func TestWatcher_RuntimeAddsRespectWatchCap(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	commitFile(t, workTree, "foo.go", "package main\n")
+
+	// Set a tight cap so a single new directory pushes us over.
+	// Initial watches: 1 gitDir + 1 workTree = 2; cap at 2 means
+	// any new dir created at runtime must be refused.
+	orig := MaxWatches
+	MaxWatches = 2
+	defer func() { MaxWatches = orig }()
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+	defer w.Close() //nolint:errcheck
+
+	startCount := w.watchCount.Load()
+
+	// Create a new directory inside the work tree. maybeWatchNewDir
+	// should observe the cap and refuse to add the watch.
+	require.NoError(t, os.MkdirAll(filepath.Join(workTree, "new-dir"), 0o755))
+	// Give the watcher goroutine a moment to handle the create event.
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, startCount, w.watchCount.Load(), "watchCount must not grow past MaxWatches")
+}
+
 func TestWatcher_AcceptsAtOrBelowWatchCap(t *testing.T) {
 	workTree, gitDir := gitInit(t)
 	for i := 0; i < 3; i++ {

--- a/internal/fswatch/watcher_test.go
+++ b/internal/fswatch/watcher_test.go
@@ -1,6 +1,7 @@
 package fswatch
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -213,6 +214,40 @@ func TestWatcher_NoEventsAfterClose(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Events channel was not closed after Close")
 	}
+}
+
+func TestWatcher_RefusesAboveWatchCap(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	// Each commit lands in its own directory, producing 10 unique tracked dirs.
+	for i := 0; i < 10; i++ {
+		commitFile(t, workTree, fmt.Sprintf("d%d/f.go", i), "package x\n")
+	}
+
+	orig := MaxWatches
+	MaxWatches = 5
+	defer func() { MaxWatches = orig }()
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	if w != nil {
+		_ = w.Close()
+	}
+	require.Error(t, err, "New should refuse when tracked dirs exceed MaxWatches")
+	assert.Contains(t, err.Error(), "watch cap")
+}
+
+func TestWatcher_AcceptsAtOrBelowWatchCap(t *testing.T) {
+	workTree, gitDir := gitInit(t)
+	for i := 0; i < 3; i++ {
+		commitFile(t, workTree, fmt.Sprintf("d%d/f.go", i), "package x\n")
+	}
+
+	orig := MaxWatches
+	MaxWatches = 100
+	defer func() { MaxWatches = orig }()
+
+	w, err := New(workTree, gitDir, testCoalesce)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
 }
 
 // drainEvents reads any pending Events for d duration, discarding them.


### PR DESCRIPTION
## Summary

- Cap `fswatch` at 500 unique tracked directories — beyond that, `New` errors and `main.go` falls through to timer-only refresh.
- Compute the unique dir set up front so we don't leak fds when refusing.
- Fixes `revise` crashing at startup with `too many open files in system` in large repos (portal has ~4,500 tracked dirs) when many instances run concurrently.

Closes #183.

## Test plan

- [x] `go test ./internal/fswatch/...` — new tests for above-cap refusal and below-cap acceptance, all existing tests pass
- [x] `make lint` clean
- [x] `make install` and run `revise` in `huntresslabs/portal` — no crash, falls through to timer-only refresh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented a watch limit (500 tracked directories) to prevent file descriptor exhaustion and startup failures in large repositories, automatically switching to timer-based refresh when exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->