### PR TITLE
Add r key to force-reload the diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Horizontal scroll in the diff view via →/← (or h/l) and mouse wheel left/right (#121)
 - `revise diff --mode=<branch|staged|staged-only|unstaged>` selects which diff to print non-interactively (default: auto-detect, same as launching the TUI) (#177)
 - `revise diff --hunks` prints TUI-style output — file path header, `[source]` tag with function context, and a line-number gutter — instead of unified diff format (#177)
+- `r` key forces a diff reload, as an escape hatch when auto-refresh has gotten stuck (e.g. fingerprint stable, polling wedged, focus reporting flaky)
 
 ### Changed
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -23,6 +23,7 @@ var allBindings = []BindingGroup{
 		{Key: "Tab/S-Tab", Desc: "Cycle diff mode", GitOnly: true},
 		{Key: "f", Desc: "Toggle fullscreen diff", GitOnly: true},
 		{Key: "Esc", Desc: "Back to file list", GitOnly: true},
+		{Key: "r", Desc: "Force refresh diff", GitOnly: true},
 		{Key: "?", Desc: "Toggle help"},
 		{Key: "q", Desc: "Quit"},
 	}},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -428,6 +428,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.prevFile()
 			return m, nil
 
+		// Hard refresh — reload diff regardless of fingerprint, so the user
+		// has an escape hatch when auto-refresh hasn't picked up a change.
+		case "r":
+			if m.fileReviewMode {
+				return m, nil
+			}
+			m.statusMsg = "Refreshing…"
+			return m, tea.Batch(
+				m.loadDiff(),
+				tea.Tick(2*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} }),
+			)
+
 		// Report issue opens GitHub new issue page
 		case "!":
 			const issueURL = "https://github.com/justincampbell/revise/issues/new/choose"

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -745,6 +745,25 @@ func TestModelReportIssue_SetsStatusAndReturnsCmd(t *testing.T) {
 	assert.NotNil(t, cmd, "should return a command to open the URL")
 }
 
+func TestModelHardRefresh_SetsStatusAndReturnsCmd(t *testing.T) {
+	m := makeModel("a.go")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "Refreshing")
+	assert.NotNil(t, cmd, "should return a command to reload the diff")
+}
+
+func TestModelHardRefresh_NoOpInFileReviewMode(t *testing.T) {
+	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, false)
+	m.fileReviewMode = true
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	m = updated.(Model)
+	assert.Empty(t, m.statusMsg)
+	assert.Nil(t, cmd)
+}
+
 func TestModelReportIssue_WorksFromDiffView(t *testing.T) {
 	m := makeModel("a.go")
 	m = sendKey(m, "l") // focus diff


### PR DESCRIPTION
## Summary

- New `r` keybind reloads the diff on demand, bypassing the focused/polling/fingerprint guards that gate auto-refresh
- Acts as an escape hatch for the cases the `--debug` strip is meant to diagnose: focus reporting flaky, polling wedged on a hung git command, or a fingerprint that genuinely does not change (e.g. amend that produces an identical working tree)
- Briefly shows "Refreshing…" in the status bar so the user gets visual feedback

## Test plan

- [x] `make lint test` — clean
- [x] Unit tests for the new key (status set, cmd returned; no-op in file review mode)
- [x] `make install` — manually verified `r` reloads the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `r` keyboard shortcut to manually force a diff refresh when auto-refresh becomes unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->