### PR TITLE
Reload diff after auto-promoting to ModeBranch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Auto-refresh now wakes on file changes (via fsnotify) and on terminal focus, instead of waiting up to 30s for the next polling tick. Cadence is adaptive — it self-throttles based on how long the last `git status` took, so running 10-20 revise instances on shared-repo worktrees no longer piles up I/O. Pass `--no-watch` (or set `REVISE_NO_WATCH=1`) to disable the fsnotify path and fall back to timer-only refreshes (#144)
 - Startup no longer runs `git update-index --test-untracked-cache`, which created `mtime-test-XXXXXX/` directories in the working tree (and left them behind if the process exited before cleanup). The startup tip now fires on any repo with `core.untrackedCache` disabled; the FS test still runs on demand inside `revise setup-cache` (#178)
 - fswatch now caps fsnotify watches at 500 — refuses to install when a repo has more tracked directories at startup, and refuses runtime adds (e.g. directories created by `npm install`) once the cap is hit. Without the cap, large repos × concurrent revise instances could exhaust the system fd limit and crash startup with `too many open files in system` (#183)
+- When a commit on the default branch causes auto-promotion to ModeBranch, the diff is now reloaded under the new mode instead of leaving stale (often empty) contents on screen until the user manually refreshes
 
 ### Added
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -622,8 +622,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// (e.g. user committed on a fresh branch), promote mode to
 		// ModeBranch so the new commits are visible — but only if the
 		// user hasn't explicitly picked a different mode (see #148).
+		// The diff in this msg was loaded under the OLD mode, so kick off
+		// a follow-up reload under the new mode; otherwise the user sees
+		// Branch mode with stale (often empty) contents.
+		var followup tea.Cmd
 		if wasOnDefaultBranch && !m.onDefaultBranch && !m.modeExplicitlySet {
 			m.mode = ModeBranch
+			followup = m.loadDiffFromPoll()
 		}
 		// If the current mode is no longer valid, clamp it.
 		modes := m.availableModes()
@@ -678,7 +683,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.diffView.offset = 0
 			m.diffView.goToTop()
 		}
-		return m, nil
+		return m, followup
 
 	case hunkApplyMsg:
 		if msg.err != nil {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -512,6 +512,28 @@ func TestDiffRefresh_SwitchesToFeatureBranch_PromotesToBranchMode(t *testing.T) 
 	assert.Equal(t, ModeBranch, m.mode, "should promote to ModeBranch when branch diverges and mode is the default")
 }
 
+// When mode auto-promotes to ModeBranch on the default→feature transition,
+// the diffLoadedMsg being applied was loaded under the OLD mode (e.g.
+// ModeStaged), so its contents are wrong for the new mode. The handler must
+// return a follow-up reload command — otherwise the user sees Branch mode
+// with empty contents until they manually refresh.
+func TestDiffRefresh_AutoPromote_KicksOffReload(t *testing.T) {
+	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, true)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	require.True(t, m.onDefaultBranch)
+	require.Equal(t, ModeStaged, m.mode)
+
+	updated, cmd := m.Update(diffLoadedMsg{
+		diff:            &git.Diff{},
+		onDefaultBranch: false,
+		fromPoll:        true,
+	})
+	m = updated.(Model)
+	require.Equal(t, ModeBranch, m.mode)
+	require.NotNil(t, cmd, "should return a follow-up command to reload the diff under the new mode")
+}
+
 // If the user explicitly picked a mode on the default branch, respect that
 // choice across the transition — don't auto-promote to ModeBranch.
 func TestDiffRefresh_SwitchesToFeatureBranch_PreservesExplicitMode(t *testing.T) {


### PR DESCRIPTION
## Summary

- When a commit on the default branch caused auto-promotion to `ModeBranch`, the diff being applied had been loaded under the pre-promotion mode (`ModeStaged` etc.) and its contents were stale for the new mode — typically empty, since the post-commit working tree is clean
- Fix is in the `diffLoadedMsg` handler at `internal/ui/model.go`: when we promote the mode, kick off a follow-up `loadDiffFromPoll()` so the next render shows the correct cumulative branch diff
- Without this, the user saw `Branch+Staged+Unstaged` in the mode slider but an empty diff until they manually refreshed (e.g. via the new `r` key)

## Test plan

- [x] New regression test `TestDiffRefresh_AutoPromote_KicksOffReload` — verifies a non-nil follow-up command is returned when promotion happens (fails before the fix)
- [x] `make lint test` — clean
- [x] `make install` — manually verified by committing on main while revise is running


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* When a commit on the default branch triggers an automatic mode change, the diff view now properly reloads to display the content in the new mode context instead of showing stale or empty information. Previously, users had to manually refresh the page to see the accurate diff information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->