### PR TITLE
Fix pane height mismatch on short content (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Startup no longer runs `git update-index --test-untracked-cache`, which created `mtime-test-XXXXXX/` directories in the working tree (and left them behind if the process exited before cleanup). The startup tip now fires on any repo with `core.untrackedCache` disabled; the FS test still runs on demand inside `revise setup-cache` (#178)
 - fswatch now caps fsnotify watches at 500 — refuses to install when a repo has more tracked directories at startup, and refuses runtime adds (e.g. directories created by `npm install`) once the cap is hit. Without the cap, large repos × concurrent revise instances could exhaust the system fd limit and crash startup with `too many open files in system` (#183)
 - When a commit on the default branch causes auto-promotion to ModeBranch, the diff is now reloaded under the new mode instead of leaving stale (often empty) contents on screen until the user manually refreshes
+- File list and diff view now always render to the same total height, so the status bar no longer "jumps up" when switching between long and short files or viewing a repo with few changes (#169)
 
 ### Added
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -670,7 +670,9 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 	if focused {
 		style = focusedBorder
 	}
-	rendered := style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(content)
+	// m.height is the inner content height; lipgloss v2 includes borders in
+	// Height(), so we pass m.height + 2 (top + bottom border).
+	rendered := style.Width(m.width).Height(m.height + 2).MaxHeight(m.height + 2).Render(content)
 
 	if m.fileReviewMode {
 		// File review mode: centered filename in top border, clean bottom border.

--- a/internal/ui/filelist.go
+++ b/internal/ui/filelist.go
@@ -95,7 +95,7 @@ func (m fileListModel) render(focused bool, modeSlider string) string {
 	}
 
 	if len(m.files) == 0 {
-		rendered := style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render("No changes")
+		rendered := style.Width(m.width).Height(m.height + 2).MaxHeight(m.height + 2).Render("No changes")
 		rendered = setBorderTitleCentered(rendered, modeSlider, focused)
 		return rendered
 	}
@@ -140,7 +140,9 @@ func (m fileListModel) render(focused bool, modeSlider string) string {
 		}
 	}
 
-	rendered := style.Width(m.width).Height(m.height).MaxHeight(m.height + 2).Render(b.String())
+	// m.height is the inner content height; lipgloss v2 includes borders in
+	// Height(), so we pass m.height + 2 (top + bottom border).
+	rendered := style.Width(m.width).Height(m.height + 2).MaxHeight(m.height + 2).Render(b.String())
 
 	rendered = setBorderTitleCentered(rendered, modeSlider, focused)
 	return rendered

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1934,3 +1934,59 @@ func TestFileReviewMode_InitReturnsNil(t *testing.T) {
 	})
 	assert.Nil(t, m.Init())
 }
+
+// TestPaneHeightsMatch is a regression test for #169: the file list and diff
+// view must render to the same total number of rows regardless of how much
+// content each pane has. Lipgloss v2 changed Height() to include borders, so
+// short content silently rendered a shorter block and the help text appeared
+// "above" the bottom of the file list. This is the invariant we now hold.
+func TestPaneHeightsMatch(t *testing.T) {
+	makeHunk := func(n int) git.Hunk {
+		lines := make([]git.Line, 0, n)
+		for i := 0; i < n; i++ {
+			lines = append(lines, git.Line{Type: git.LineAdded, Content: "line"})
+		}
+		return git.Hunk{Header: "@@ -1 +1 @@", Lines: lines}
+	}
+
+	cases := []struct {
+		name       string
+		fileCount  int
+		diffLines  int
+		termHeight int
+		termWidth  int
+	}{
+		{"few files, short diff", 2, 1, 40, 120},
+		{"few files, long diff", 2, 200, 40, 120},
+		{"many files, short diff", 100, 1, 40, 120},
+		{"many files, long diff", 100, 200, 40, 120},
+		{"narrow terminal", 2, 1, 40, 60},
+		{"tall terminal", 5, 5, 80, 100},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			files := make([]git.FileDiff, tc.fileCount)
+			hunk := makeHunk(tc.diffLines)
+			for i := range files {
+				files[i] = git.FileDiff{
+					Path:   fmt.Sprintf("file_%d.txt", i),
+					Status: git.StatusModified,
+					Hunks:  []git.Hunk{hunk},
+				}
+			}
+			m := New(&git.Diff{Files: files}, false)
+			updated, _ := m.Update(tea.WindowSizeMsg{Width: tc.termWidth, Height: tc.termHeight})
+			mm := updated.(Model)
+
+			left := mm.fileList.render(true, "Branch+Staged+Unstaged")
+			right := mm.diffView.render(false, mm.contextLines, mm.hideWhitespace)
+			leftRows := strings.Count(left, "\n") + 1
+			rightRows := strings.Count(right, "\n") + 1
+
+			assert.Equal(t, leftRows, rightRows,
+				"file list (%d rows) and diff view (%d rows) must have the same height",
+				leftRows, rightRows)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Lipgloss v2 changed `Height(n)` to mean total block height (including borders), where v1 meant content height. The model still passed `Height(m.height)` intending content height, so the rendered block was 2 rows shorter than intended whenever content didn't already fill the pane.
- Visible as the file list looking "too short" with a gap above the status bar when viewing a long diff, and the diff view shrinking to fit small files (the help text "jumps up" to the bottom of the file list).
- Fix: pass `m.height + 2` to account for the top and bottom border rows at the three lipgloss render call sites.
- Adds a regression test `TestPaneHeightsMatch` that asserts the file list and diff view always render to the same total height across various file counts, diff lengths, and terminal sizes.

Closes #169.

## Test plan

- [x] `go test ./...`
- [x] `make lint`
- [ ] Open in a repo with one file modified — file list border reaches the status bar
- [ ] Switch between a long file and a short file — diff view height is stable, help text doesn't move

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed status bar jumping when switching between files or viewing repositories with few changes—file list and diff view now consistently render to the same total height.

* **Tests**
  * Added regression test to verify pane heights remain consistent across different file counts and terminal sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->