### PR TITLE
Support repos with no commits yet (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `revise` no longer exits with `Error: repository has no commits` when run in a repo with no commits. The TUI launches normally, showing staged and untracked files with a "No commits yet" hint in the status bar (#189)
+
 ## [0.4.0] - 2026-05-08
 
 ### Added

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -515,13 +515,12 @@ func WorkingTreeDiffOptions(contextLines int, hideWhitespace bool) (*Diff, error
 // GetDiff returns a parsed Diff for the current branch vs the default branch.
 // If on the default branch, it shows working tree changes (staged + unstaged).
 // Otherwise it shows committed changes vs merge-base plus working tree changes.
+// In a repo with no commits, IsOnDefaultBranch returns true and the working
+// tree diff still surfaces staged + untracked files via the empty-tree implicit
+// base used by `git diff --cached`.
 func GetDiff() (*Diff, error) {
 	if !IsGitRepo() {
 		return nil, fmt.Errorf("not a git repository")
-	}
-
-	if !HasCommits() {
-		return nil, fmt.Errorf("repository has no commits")
 	}
 
 	onDefault, err := IsOnDefaultBranch()

--- a/internal/git/diff_integration_test.go
+++ b/internal/git/diff_integration_test.go
@@ -464,6 +464,14 @@ func TestIsOnDefaultBranch_FeatureBranchNoCommitsBehindRemote(t *testing.T) {
 	assert.True(t, onDefault, "feature branch with no commits should be treated as default branch")
 }
 
+func TestIsOnDefaultBranch_EmptyRepo(t *testing.T) {
+	r := NewTestRepo(t)
+	r.Chdir()
+	onDefault, err := IsOnDefaultBranch()
+	require.NoError(t, err)
+	assert.True(t, onDefault, "empty repo should be treated as default branch")
+}
+
 func TestIsOnDefaultBranch_BehindRemote(t *testing.T) {
 	r := behindRemoteRepo(t)
 	_ = r
@@ -563,6 +571,41 @@ func TestWorkingTreeDiff_ShowsStagedUnstagedUntracked(t *testing.T) {
 	assert.Contains(t, paths, "staged.go")
 	assert.Contains(t, paths, "base.go")
 	assert.Contains(t, paths, "untracked.go")
+}
+
+func TestWorkingTreeDiff_EmptyRepo_Untracked(t *testing.T) {
+	r := NewTestRepo(t)
+	r.Chdir()
+	r.WriteFile("hello.go", "package main\n\nfunc main() {}\n")
+
+	diff, err := WorkingTreeDiff(DefaultContextLines)
+	require.NoError(t, err)
+	paths := filePaths(diff)
+	assert.Contains(t, paths, "hello.go")
+}
+
+func TestWorkingTreeDiff_EmptyRepo_Staged(t *testing.T) {
+	r := NewTestRepo(t)
+	r.Chdir()
+	r.WriteFile("hello.go", "package main\n\nfunc main() {}\n")
+	r.Add("hello.go")
+
+	diff, err := WorkingTreeDiff(DefaultContextLines)
+	require.NoError(t, err)
+	paths := filePaths(diff)
+	assert.Contains(t, paths, "hello.go")
+	assertHasContent(t, *fileByPath(diff, "hello.go"), "func main")
+}
+
+func TestGetDiff_EmptyRepo(t *testing.T) {
+	r := NewTestRepo(t)
+	r.Chdir()
+	r.WriteFile("hello.go", "package main\n")
+	r.Add("hello.go")
+
+	diff, err := GetDiff()
+	require.NoError(t, err)
+	assert.Contains(t, filePaths(diff), "hello.go")
 }
 
 // Same file with both staged and unstaged changes should appear once with hunks from both.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -71,6 +71,7 @@ type diffLoadedMsg struct {
 	diff            *git.Diff
 	err             error
 	onDefaultBranch bool
+	noCommits       bool          // true if the repo has no commits at load time
 	fromPoll        bool          // true when triggered by auto-refresh polling
 	duration        time.Duration // time the diff load took (used by --debug overlay)
 }
@@ -119,6 +120,7 @@ type Model struct {
 	mode              DiffMode
 	modeExplicitlySet bool // true once the user has manually picked a mode (#148)
 	onDefaultBranch   bool
+	noCommits         bool // true when the repo has no commits yet (#189)
 	contextLines      int
 	hideWhitespace    bool
 
@@ -240,6 +242,7 @@ func NewWithStorePath(diff *git.Diff, onDefaultBranch bool, storePath string, ve
 		storePath:       storePath,
 		mode:            mode,
 		onDefaultBranch: onDefaultBranch,
+		noCommits:       !git.HasCommits(),
 		contextLines:    git.DefaultContextLines,
 		refreshPolicy:   refresh.Default,
 		lastFingerprint: initialFP,
@@ -613,6 +616,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
 		}
 		m.diff = msg.diff
+		m.noCommits = msg.noCommits
 
 		// Update default-branch status so Branch mode becomes
 		// available (or unavailable) dynamically.
@@ -1426,7 +1430,7 @@ func (m *Model) loadDiffWithOptions(fromPoll bool) tea.Cmd {
 		case ModeUnstaged:
 			diff, err = git.UnstagedOnlyDiffOptions(ctx, hideWS)
 		}
-		return diffLoadedMsg{diff: diff, err: err, onDefaultBranch: onDefault, fromPoll: fromPoll, duration: time.Since(start)}
+		return diffLoadedMsg{diff: diff, err: err, onDefaultBranch: onDefault, noCommits: !git.HasCommits(), fromPoll: fromPoll, duration: time.Since(start)}
 	}
 }
 
@@ -1600,6 +1604,11 @@ func (m Model) renderStatusBar() string {
 	}
 
 	helpHint := helpKeyStyle.Render("?") + statusBarStyle.Render(" help")
+
+	if m.noCommits {
+		hint := statusBarStyle.Render("No commits yet — staged and untracked files only  ") + helpHint
+		return statusBarStyle.Width(m.width).Render(hint)
+	}
 
 	count := len(m.comments)
 	if count > 0 {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1223,6 +1223,22 @@ func TestRenderStatusBar_DiffNoPaneTotals(t *testing.T) {
 	assert.NotContains(t, status, "a.go +1/-1")
 }
 
+func TestRenderStatusBar_NoCommitsHint(t *testing.T) {
+	m := New(&git.Diff{}, true)
+	m.noCommits = true
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	assert.Contains(t, m.renderStatusBar(), "No commits yet")
+}
+
+func TestRenderStatusBar_NoCommitsHintHiddenWhenCommitsExist(t *testing.T) {
+	m := New(&git.Diff{}, true)
+	m.noCommits = false
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	assert.NotContains(t, m.renderStatusBar(), "No commits yet")
+}
+
 // --- Comment persistence tests ---
 
 // makeModelWithStore creates a model with diff lines and a temp store path.

--- a/main.go
+++ b/main.go
@@ -97,14 +97,11 @@ func main() {
 		}
 	}
 
-	// All remaining paths require a git repo with commits.
+	// All remaining paths require a git repo. Repos with no commits are
+	// supported — the TUI surfaces staged + untracked files and a status
+	// hint that no commits exist yet.
 	if !git.IsGitRepo() {
 		fmt.Fprintln(os.Stderr, "Error: not a git repository")
-		os.Exit(1)
-	}
-
-	if !git.HasCommits() {
-		fmt.Fprintln(os.Stderr, "Error: repository has no commits")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary

- Drop the early `Error: repository has no commits` exit so `revise` launches the TUI in a fresh repo
- Show a persistent "No commits yet — staged and untracked files only" hint in the status bar; the hint clears automatically once the first commit lands (state refreshed on every diff reload)
- `GetDiff` no longer guards on `HasCommits`; `WorkingTreeDiff` and `IsOnDefaultBranch` already handle the empty-repo case (git treats `--cached` as a diff against the empty tree, and `MergeBase` failure already falls through to "treat as default branch")

Closes #189.

## Test plan

- [x] `go test ./...`
- [x] `make lint`
- [x] `revise diff` in a fresh repo with one untracked file → shows the new-file diff
- [x] `revise diff --mode staged-only` in a fresh repo with one staged file → shows the staged additions
- [ ] Launch TUI in a fresh repo (`git init` + `echo hi > foo.txt`) and confirm the "No commits yet" hint appears
- [ ] Commit the file inside the same `revise` session and confirm the hint disappears on next refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `revise` exiting with an error when run in repositories with no commits. The application now starts normally and displays a "No commits yet" hint in the status bar, allowing users to view staged and untracked files.

* **Chores**
  * Added test coverage for empty repository edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/justincampbell/revise/pull/190)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->