### PR TITLE
Open current file in $EDITOR with E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `E` opens the current file at the cursor line in `$VISUAL`/`$EDITOR` (falls back to `vi`); the TUI suspends until the editor exits, then reloads the diff so any edits show up immediately. Recognizes vim/nvim/nano/emacs (`+N file`), VS Code/Cursor/Codium (`--goto file:N`), and Sublime/Zed/Atom (`file:N`); other editors fall back to the `+N` form (#191)
+
 ## [0.4.2] - 2026-05-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,9 @@ internal/
   devwatch/
     devwatch.go                # poll a binary for changes, fire callback on replacement (--dev flag)
     devwatch_test.go           # watcher unit tests
+  editor/
+    editor.go                  # build $VISUAL/$EDITOR command with file+line args (E key)
+    editor_test.go             # unit tests for editor command construction
   update/
     update.go                  # self-update via go-selfupdate (CheckForUpdate, ApplyUpdate)
     update_test.go             # integration tests (skipped in short mode)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Press `?` inside revise to see the help overlay.
 | Key | Action |
 |-----|--------|
 | `e` | Export comments to clipboard |
-| `E` | Open current file at cursor line in `$EDITOR` |
+| `E` | Open current file at cursor line in `$VISUAL`/`$EDITOR` (fallback: `vi`) |
 | `!` | Report issue on GitHub |
 
 ## Inspiration

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Press `?` inside revise to see the help overlay.
 | Key | Action |
 |-----|--------|
 | `e` | Export comments to clipboard |
+| `E` | Open current file at cursor line in `$EDITOR` |
 | `!` | Report issue on GitHub |
 
 ## Inspiration

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1,0 +1,65 @@
+// Package editor builds a command to open a file (and optionally a specific
+// line) in the user's preferred editor, based on $VISUAL / $EDITOR.
+package editor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultEditor is used when neither $VISUAL nor $EDITOR is set.
+const DefaultEditor = "vi"
+
+// Command builds an *exec.Cmd that opens filePath in the user's editor at
+// the given lineNum. Pass lineNum <= 0 to skip the line argument.
+//
+// $VISUAL is preferred over $EDITOR (the historical convention: $VISUAL is
+// for full-screen editors, $EDITOR for line editors). Both env vars may
+// include arguments (e.g. `code --wait`); they are tokenized on whitespace.
+//
+// The line-number argument format depends on the editor binary:
+//   - vim/nvim/vi/nano/emacs/pico: `+N file`
+//   - code/code-insiders/code-oss/cursor/codium/windsurf: `--goto file:N`
+//   - subl/sublime_text/atom/zed/mate/rmate/hx (helix): `file:N`
+//
+// Whitespace splitting is naive (strings.Fields) — editor strings with
+// quoted args or paths containing spaces aren't supported. Users with
+// unusual setups can wrap their editor in a shell script.
+func Command(filePath string, lineNum int) (*exec.Cmd, error) {
+	ed := os.Getenv("VISUAL")
+	if ed == "" {
+		ed = os.Getenv("EDITOR")
+	}
+	if ed == "" {
+		ed = DefaultEditor
+	}
+
+	parts := strings.Fields(ed)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("editor command is empty")
+	}
+	bin := parts[0]
+	args := append([]string(nil), parts[1:]...)
+	args = append(args, fileArgs(filepath.Base(bin), filePath, lineNum)...)
+	return exec.Command(bin, args...), nil
+}
+
+// fileArgs returns the editor-specific arguments for opening filePath at
+// lineNum. Pulled out for unit testing without invoking exec.
+func fileArgs(bin, filePath string, lineNum int) []string {
+	if lineNum <= 0 {
+		return []string{filePath}
+	}
+	switch bin {
+	case "code", "code-insiders", "code-oss", "codium", "vscodium", "cursor", "windsurf":
+		return []string{"--goto", fmt.Sprintf("%s:%d", filePath, lineNum)}
+	case "subl", "sublime_text", "atom", "zed", "mate", "rmate", "hx", "helix":
+		return []string{fmt.Sprintf("%s:%d", filePath, lineNum)}
+	default:
+		// vi, vim, nvim, nano, emacs, emacsclient, pico, jove, joe…
+		return []string{fmt.Sprintf("+%d", lineNum), filePath}
+	}
+}

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -1,0 +1,108 @@
+package editor
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFileArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		bin     string
+		path    string
+		lineNum int
+		want    []string
+	}{
+		{"vim with line", "vim", "main.go", 42, []string{"+42", "main.go"}},
+		{"nvim with line", "nvim", "main.go", 42, []string{"+42", "main.go"}},
+		{"vi with line", "vi", "main.go", 1, []string{"+1", "main.go"}},
+		{"nano with line", "nano", "main.go", 7, []string{"+7", "main.go"}},
+		{"emacs with line", "emacs", "main.go", 9, []string{"+9", "main.go"}},
+		{"vscode --goto", "code", "main.go", 42, []string{"--goto", "main.go:42"}},
+		{"vscode insiders", "code-insiders", "main.go", 1, []string{"--goto", "main.go:1"}},
+		{"code-oss (linux)", "code-oss", "main.go", 1, []string{"--goto", "main.go:1"}},
+		{"codium", "codium", "main.go", 1, []string{"--goto", "main.go:1"}},
+		{"cursor", "cursor", "main.go", 1, []string{"--goto", "main.go:1"}},
+		{"windsurf", "windsurf", "main.go", 1, []string{"--goto", "main.go:1"}},
+
+		{"sublime", "subl", "main.go", 42, []string{"main.go:42"}},
+		{"zed", "zed", "main.go", 5, []string{"main.go:5"}},
+		{"atom", "atom", "main.go", 5, []string{"main.go:5"}},
+		{"helix (hx)", "hx", "main.go", 5, []string{"main.go:5"}},
+		{"helix (full name)", "helix", "main.go", 5, []string{"main.go:5"}},
+
+		{"no line: skips line arg", "vim", "main.go", 0, []string{"main.go"}},
+		{"negative line: skips line arg", "vim", "main.go", -1, []string{"main.go"}},
+		{"unknown editor: defaults to +N FILE", "foobar", "main.go", 3, []string{"+3", "main.go"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fileArgs(tt.bin, tt.path, tt.lineNum)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("fileArgs(%q, %q, %d) = %v, want %v", tt.bin, tt.path, tt.lineNum, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommand_PicksVisualOverEditor(t *testing.T) {
+	t.Setenv("VISUAL", "code --wait")
+	t.Setenv("EDITOR", "vim")
+
+	cmd, err := Command("main.go", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := cmd.Path; !strings.HasSuffix(got, "code") {
+		t.Errorf("Path = %q, want suffix 'code'", got)
+	}
+	// Args[0] is the binary; subsequent args are from the editor string and fileArgs.
+	want := []string{"code", "--wait", "--goto", "main.go:10"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Errorf("Args = %v, want %v", cmd.Args, want)
+	}
+}
+
+func TestCommand_FallsBackToEditor(t *testing.T) {
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "vim")
+
+	cmd, err := Command("main.go", 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"vim", "+3", "main.go"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Errorf("Args = %v, want %v", cmd.Args, want)
+	}
+}
+
+func TestCommand_DefaultsToVi(t *testing.T) {
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "")
+
+	cmd, err := Command("main.go", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"vi", "main.go"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Errorf("Args = %v, want %v", cmd.Args, want)
+	}
+}
+
+func TestCommand_EditorWithFlags(t *testing.T) {
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "nvim -u NONE")
+
+	cmd, err := Command("main.go", 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"nvim", "-u", "NONE", "+7", "main.go"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Errorf("Args = %v, want %v", cmd.Args, want)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -53,7 +53,7 @@ var allBindings = []BindingGroup{
 	}},
 	{"Global", []Binding{
 		{Key: "e", Desc: "Export comments to clipboard"},
-		{Key: "E", Desc: "Open current file at cursor line in $EDITOR"},
+		{Key: "E", Desc: "Open current file at cursor line in $VISUAL/$EDITOR"},
 		{Key: "C", Desc: "Clear all comments"},
 		{Key: "Ctrl+U", Desc: "Apply available update", GitOnly: true},
 		{Key: "!", Desc: "Report issue on GitHub"},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -53,6 +53,7 @@ var allBindings = []BindingGroup{
 	}},
 	{"Global", []Binding{
 		{Key: "e", Desc: "Export comments to clipboard"},
+		{Key: "E", Desc: "Open current file at cursor line in $EDITOR"},
 		{Key: "C", Desc: "Clear all comments"},
 		{Key: "Ctrl+U", Desc: "Apply available update", GitOnly: true},
 		{Key: "!", Desc: "Report issue on GitHub"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	commentstore "github.com/justincampbell/revise/internal/comments"
+	"github.com/justincampbell/revise/internal/editor"
 	"github.com/justincampbell/revise/internal/fswatch"
 	"github.com/justincampbell/revise/internal/git"
 	"github.com/justincampbell/revise/internal/refresh"
@@ -64,6 +67,14 @@ type untrackedCacheTipMsg struct{}
 type updateAppliedMsg struct {
 	newVersion string
 	err        error
+}
+
+// editorFinishedMsg is sent when the $EDITOR process exits after `E`.
+// The handler reloads the diff so any edits the user made are visible
+// immediately on return (file review mode skips the reload since there's
+// no diff to refresh; the user can `r` if needed).
+type editorFinishedMsg struct {
+	err error
 }
 
 // diffLoadedMsg is sent when an async diff load completes.
@@ -443,6 +454,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tea.Tick(2*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} }),
 			)
 
+		// Open current file at the cursor line in $EDITOR (suspends the TUI).
+		case "E":
+			if cmd := m.openInEditor(); cmd != nil {
+				return m, cmd
+			}
+			return m, nil
+
 		// Report issue opens GitHub new issue page
 		case "!":
 			const issueURL = "https://github.com/justincampbell/revise/issues/new/choose"
@@ -693,6 +711,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.statusMsg = "Error: " + msg.err.Error()
 			return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+		}
+		return m, m.loadDiff()
+
+	case editorFinishedMsg:
+		// Editor exited cleanly OR with a non-zero exit code (e.g. `:cq`
+		// in vim, which users do intentionally to signal "cancel"). Both
+		// are normal — only flag the message if exec itself failed
+		// (binary not found, permission denied, etc.).
+		var exitErr *exec.ExitError
+		if msg.err != nil && !errors.As(msg.err, &exitErr) {
+			m.statusMsg = "Editor error: " + msg.err.Error()
+			return m, tea.Tick(5*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+		}
+		if m.fileReviewMode {
+			return m, nil
 		}
 		return m, m.loadDiff()
 
@@ -1178,6 +1211,55 @@ func (m *Model) discardCurrentFile() tea.Cmd {
 		return hunkApplyMsg{err: err}
 	}
 	return nil
+}
+
+// openInEditor suspends the TUI and runs $VISUAL/$EDITOR on the current
+// file at the cursor line. On return, an editorFinishedMsg triggers a
+// diff reload so any edits show up immediately.
+//
+// When the cursor isn't on a code line (hunk header, comment display row,
+// file with no diff), lineNum falls back to 0 and the editor opens the
+// file at its top.
+//
+// Returns nil (no-op) if there's no file selected.
+func (m *Model) openInEditor() tea.Cmd {
+	file := m.diffView.file
+	if file == nil {
+		return nil
+	}
+	// Deleted files don't exist on disk — opening one in the editor
+	// would either error out (VS Code) or create an empty buffer that
+	// silently re-adds the file on save. Block with a hint instead.
+	if file.Status == git.StatusDeleted {
+		m.statusMsg = "Cannot edit deleted file"
+		return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+	}
+	filePath := file.Path
+	// In git diff mode, file paths are repo-relative. Resolve to absolute
+	// so the editor opens the right file even when revise was launched
+	// from a subdirectory. In file review mode, the path is whatever the
+	// user passed to `revise <file>` — use it as-is.
+	if !m.fileReviewMode {
+		if root, err := git.RepoRoot(); err == nil {
+			filePath = filepath.Join(root, filePath)
+		}
+	}
+	lineNum := 0
+	if ref := m.diffView.cursorRef(); ref != nil {
+		if ref.lineType == git.LineRemoved {
+			lineNum = ref.oldNum
+		} else {
+			lineNum = ref.newNum
+		}
+	}
+	cmd, err := editor.Command(filePath, lineNum)
+	if err != nil {
+		m.statusMsg = "Editor error: " + err.Error()
+		return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+	}
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return editorFinishedMsg{err: err}
+	})
 }
 
 // fileHasSource returns true if any hunk in the file has the given source.

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -2005,4 +2006,82 @@ func TestPaneHeightsMatch(t *testing.T) {
 				leftRows, rightRows)
 		})
 	}
+}
+
+func TestModelE_ReturnsExecCmdWhenFileSelected(t *testing.T) {
+	t.Setenv("EDITOR", "true") // any benign binary
+	m := makeModelWithDiff("foo.go", []git.Line{
+		{Type: git.LineContext, Content: "line one", OldNum: 1, NewNum: 1},
+	})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("E")})
+	m = updated.(Model)
+	assert.NotNil(t, cmd, "E should return a tea.ExecProcess command")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelE_NoOpWithNoFile(t *testing.T) {
+	t.Setenv("EDITOR", "true")
+	m := New(&git.Diff{Files: nil}, false)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("E")})
+	m = updated.(Model)
+	assert.Nil(t, cmd, "E with no file should be a no-op")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelEditorFinished_ReloadsDiffInGitMode(t *testing.T) {
+	m := makeModel("a.go")
+	updated, cmd := m.Update(editorFinishedMsg{err: nil})
+	m = updated.(Model)
+	assert.NotNil(t, cmd, "editorFinishedMsg should trigger a diff reload")
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelEditorFinished_NoReloadInFileReviewMode(t *testing.T) {
+	m := New(&git.Diff{Files: []git.FileDiff{{Path: "a.go", Status: git.StatusModified}}}, false)
+	m.fileReviewMode = true
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	updated, cmd := m.Update(editorFinishedMsg{err: nil})
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+	assert.Empty(t, m.statusMsg)
+}
+
+func TestModelEditorFinished_ShowsStatusOnExecError(t *testing.T) {
+	m := makeModel("a.go")
+	// A bare error (not *exec.ExitError) represents "couldn't launch the
+	// editor at all" — the user should see this.
+	updated, cmd := m.Update(editorFinishedMsg{err: fmt.Errorf("boom")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "Editor error")
+	assert.Contains(t, m.statusMsg, "boom")
+	assert.NotNil(t, cmd, "should return a clearStatusMsg tick")
+}
+
+func TestModelEditorFinished_SilentOnExitError(t *testing.T) {
+	m := makeModel("a.go")
+	// Simulate vim's `:cq` (exit non-zero) by running a real command that exits 1.
+	c := exec.Command("sh", "-c", "exit 1")
+	_ = c.Run()
+	exitErr, ok := c.ProcessState.ExitCode(), c.ProcessState.Exited()
+	require.True(t, ok && exitErr != 0, "test setup: expected non-zero exit")
+
+	updated, cmd := m.Update(editorFinishedMsg{err: &exec.ExitError{ProcessState: c.ProcessState}})
+	m = updated.(Model)
+	assert.Empty(t, m.statusMsg, "exit-code errors should not surface a status message")
+	assert.NotNil(t, cmd, "should still reload the diff after the editor exits")
+}
+
+func TestModelE_DeletedFileShowsStatus(t *testing.T) {
+	t.Setenv("EDITOR", "true")
+	files := []git.FileDiff{{Path: "gone.go", Status: git.StatusDeleted}}
+	m := New(&git.Diff{Files: files}, false)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("E")})
+	m = updated.(Model)
+	assert.Contains(t, m.statusMsg, "deleted")
+	assert.NotNil(t, cmd, "should return a clearStatusMsg tick")
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -2062,13 +2063,19 @@ func TestModelEditorFinished_ShowsStatusOnExecError(t *testing.T) {
 
 func TestModelEditorFinished_SilentOnExitError(t *testing.T) {
 	m := makeModel("a.go")
-	// Simulate vim's `:cq` (exit non-zero) by running a real command that exits 1.
-	c := exec.Command("sh", "-c", "exit 1")
-	_ = c.Run()
-	exitErr, ok := c.ProcessState.ExitCode(), c.ProcessState.Exited()
-	require.True(t, ok && exitErr != 0, "test setup: expected non-zero exit")
+	// Simulate vim's `:cq` (exit non-zero) by running a real command that
+	// exits 1, then re-using its *exec.ExitError so the model's errors.As
+	// sees the actual error type the runtime would surface.
+	var c *exec.Cmd
+	if runtime.GOOS == "windows" {
+		c = exec.Command("cmd", "/C", "exit 1")
+	} else {
+		c = exec.Command("sh", "-c", "exit 1")
+	}
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, c.Run(), &exitErr, "test setup: expected non-zero exit")
 
-	updated, cmd := m.Update(editorFinishedMsg{err: &exec.ExitError{ProcessState: c.ProcessState}})
+	updated, cmd := m.Update(editorFinishedMsg{err: exitErr})
 	m = updated.(Model)
 	assert.Empty(t, m.statusMsg, "exit-code errors should not surface a status message")
 	assert.NotNil(t, cmd, "should still reload the diff after the editor exits")


### PR DESCRIPTION
## Summary

Adds `E` to open the current file at the cursor line in `$VISUAL`/`$EDITOR`. The TUI suspends via `tea.ExecProcess`, then reloads the diff on return so any edits show up immediately. Closes #191.

Editor argument shape is picked per binary:
- `vim`/`nvim`/`nano`/`emacs`/etc — `+N file`
- VS Code family (`code`/`code-insiders`/`code-oss`/`codium`/`cursor`/`windsurf`) — `--goto file:N`
- `subl`/`sublime_text`/`atom`/`zed`/`mate`/`rmate`/`hx`/`helix` — `file:N`

Other binaries fall back to `+N file`. The new `internal/editor` package keeps this logic pure and unit-testable.

Edge cases handled:
- Deleted files block with a status hint (no on-disk target to edit).
- `*exec.ExitError` from the editor is benign (so vim `:cq` doesn't pop an error toast), but `exec.Error` (e.g. binary not found) still surfaces.
- File paths are resolved against the repo root in git diff mode so the editor opens the right file when revise was launched from a subdirectory; file review mode passes the user-supplied path through as-is.

## Test plan

- [ ] `make` passes (lint + tests)
- [ ] Press `E` on a code line — opens `$EDITOR` at that line, returns to revise, diff reloads
- [ ] Press `E` on a removed line — opens at the old line number
- [ ] Press `E` on a deleted file — shows "Cannot edit deleted file"
- [ ] Press `E` in `revise <file>` review mode — opens the file at the cursor line
- [ ] `:cq` in vim — returns to revise without an error toast
- [ ] `EDITOR=nope E` — surfaces an "Editor error: ..." status

- [x] Update CHANGELOG.md if user-facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `E` key to open the current file at your cursor position in the editor (`$VISUAL`/`$EDITOR`, defaulting to `vi`). TUI suspends during editing and automatically reloads the diff afterward.

* **Documentation**
  * Updated keyboard bindings documentation to include the new editor feature.

* **Tests**
  * Added comprehensive test coverage for editor functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/justincampbell/revise/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->