### PR TITLE
Doc-review features: soft wrap, blank-line jumps, diff search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `/` starts an incremental search in the diff view: the matched text highlights as you type (the rest of the line keeps its syntax colors), the cursor jumps to the nearest match, and `n`/`N` step forward/backward between matches (wrapping). Off-screen matches scroll into view horizontally. The status bar shows a `current/total` count; `Esc` clears the search. Case-insensitive and scoped to the current file. Works in both git diff and file review mode — `n`/`N` keep their next/prev-file meaning when no search is active (#72)
 - `W` toggles soft line wrap in the diff view, wrapping long lines onto multiple display rows at the viewport width instead of clipping them. Continuation rows are indented past the line-number gutter so content stays aligned; a `Wrap` indicator appears on the bottom border when enabled. Works in both git diff and file review mode — useful for reviewing prose-heavy planning/architecture docs (#163)
 - `E` opens the current file at the cursor line in `$VISUAL`/`$EDITOR` (falls back to `vi`); the TUI suspends until the editor exits, then reloads the diff so any edits show up immediately. Recognizes vim/nvim/nano/emacs (`+N file`), VS Code/Cursor/Codium (`--goto file:N`), and Sublime/Zed/Atom (`file:N`); other editors fall back to the `+N` form (#191)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `W` toggles soft line wrap in the diff view, wrapping long lines onto multiple display rows at the viewport width instead of clipping them. Continuation rows are indented past the line-number gutter so content stays aligned; a `Wrap` indicator appears on the bottom border when enabled. Works in both git diff and file review mode — useful for reviewing prose-heavy planning/architecture docs (#163)
 - `E` opens the current file at the cursor line in `$VISUAL`/`$EDITOR` (falls back to `vi`); the TUI suspends until the editor exits, then reloads the diff so any edits show up immediately. Recognizes vim/nvim/nano/emacs (`+N file`), VS Code/Cursor/Codium (`--goto file:N`), and Sublime/Zed/Atom (`file:N`); other editors fall back to the `+N` form (#191)
 
 ## [0.4.2] - 2026-05-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `W` toggles soft line wrap in the diff view, wrapping long lines onto multiple display rows at the viewport width instead of clipping them. Continuation rows are indented past the line-number gutter so content stays aligned; a `Wrap` indicator appears on the bottom border when enabled. Works in both git diff and file review mode — useful for reviewing prose-heavy planning/architecture docs (#163)
 - `E` opens the current file at the cursor line in `$VISUAL`/`$EDITOR` (falls back to `vi`); the TUI suspends until the editor exits, then reloads the diff so any edits show up immediately. Recognizes vim/nvim/nano/emacs (`+N file`), VS Code/Cursor/Codium (`--goto file:N`), and Sublime/Zed/Atom (`file:N`); other editors fall back to the `+N` form (#191)
 
+### Changed
+
+- `}`/`{` (`]`/`[`) now jump to the next/previous blank line (Vim-style paragraph boundary) in **all** modes, instead of jumping between hunks. In a diff the nearest blank line is usually right at the next change, so this still serves as change-to-change navigation while behaving consistently with file review mode. Dedicated hunk-to-hunk navigation is removed (#122)
+
 ## [0.4.2] - 2026-05-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,4 +217,15 @@ The fs watcher is attached via `Model.WithFSWatcher(w)`. If `fswatch.New` fails 
 - `parseFilePath` handles both standard (`diff --git a/foo b/foo`) and no-prefix (`diff --git foo foo`) formats — the latter occurs when `diff.noprefix=true` is set in the user's git config
 - `padRight` and all column-width calculations use rune count (`len([]rune(s))`), not byte length, to handle multi-byte Unicode characters like arrow symbols correctly
 
+### Soft Line Wrap
+
+`W` (or `Alt+Z`) toggles `diffViewModel.wrapEnabled`. The key design choice: `cursor` and `offset` stay **logical-line** indices into `lines[]` — wrap only changes how lines map to display rows. This keeps all navigation (hunks, marks, comments) working unchanged.
+
+The display-row math lives in a few primitives in `diffview.go`:
+- `displayRows(idx, avail, hOffset)` — the single source of truth for how a logical line renders: one row (truncated) when wrap is off, multiple word-wrapped rows when on. Continuation rows are indented by the gutter width (6) so content aligns; wrapping uses `ansi.Wrap` after splitting gutter from content so styling is preserved.
+- `lineRows`/`rowSpan`/`lineAtRow` — derive row counts and map display-row offsets back to logical lines.
+- `ensureCursorVisible`/`bottomOffset`/`lastVisibleLine` — replace the old inline `offset = cursor - viewHeight + 1` arithmetic everywhere (moveCursor, hunk jumps, rebuild, scroll clamp). When wrap is off they reduce to the original behavior, so existing tests still hold.
+
+`clickToAbsIdx` and `scrollForCommentInput` go through the same primitives, so mouse clicks and the inline comment box stay correct with wrap on. Horizontal scroll is disabled (hOffset forced to 0) while wrapping.
+
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,17 @@ The fs watcher is attached via `Model.WithFSWatcher(w)`. If `fswatch.New` fails 
 - `parseFilePath` handles both standard (`diff --git a/foo b/foo`) and no-prefix (`diff --git foo foo`) formats — the latter occurs when `diff.noprefix=true` is set in the user's git config
 - `padRight` and all column-width calculations use rune count (`len([]rune(s))`), not byte length, to handle multi-byte Unicode characters like arrow symbols correctly
 
+### Incremental Search
+
+`/` opens a search box (rendered in the status bar, not as an overlay) for incremental search in the diff view. Design (#72):
+
+- **Scope**: the current file's diff only. `setFile` clears the search, so switching files resets it. Cross-file search was deliberately left out to keep `n`/`N` unambiguous.
+- **Case-insensitive**, rune-safe matching via `matchRanges` (returns `[start,end)` rune-index ranges) and `lineContainsQuery`.
+- **Highlighting happens at build time but preserves syntax colors**: `buildLines` passes `m.searchQuery` to `renderDiffLine`, which first renders the line normally (syntax highlight or base diff-line style), then calls `overlaySearchHighlight` to re-style *only the matched columns* with `searchMatchStyle`. The overlay slices the already-styled string by visual column (`clipCols` → `ansi.TruncateLeft`/`ansi.Truncate`, then `ansi.Strip` + restyle the matched slice), so the rest of the line keeps its colors. `matchColumnRanges` converts rune-index matches to visual columns (wide-rune-safe). `setSearch` calls `buildLines` on every keystroke; matches don't add/remove lines, so cursor indices stay stable.
+- **Match list**: `searchMatches` holds navigable line indices containing the query; `searchIdx` is the current position (-1 when none). `computeSearchMatches` scans `lineRef.content` (plain source text, stored at build time).
+- **Navigation**: `nextMatch`/`prevMatch` wrap. After moving, `ensureMatchVisible` scrolls horizontally (when wrap is off) so an off-screen match is brought into the viewport. `n`/`N` in `model.go` route to these when `searchQuery != ""`, otherwise to next/prev file (the default). While the search box is open, all keys (including `n`/`N`) feed the query.
+- **Lifecycle**: `/` → `startSearch` (records `searchOrigin = cursor`, focuses the diff view). Typing → `setSearch` (incremental: rebuild, recompute, jump to first match at/after `searchOrigin`, wrapping). `Enter` commits (box closes, query/matches retained, status bar shows `current/total` + nav hint). `Esc` clears — both inside the box and after committing (a guard before the main key switch in `Update` intercepts `esc` when `searchQuery != ""`).
+
 ### Soft Line Wrap
 
 `W` (or `Alt+Z`) toggles `diffViewModel.wrapEnabled`. The key design choice: `cursor` and `offset` stay **logical-line** indices into `lines[]` — wrap only changes how lines map to display rows. This keeps all navigation (hunks, marks, comments) working unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,8 @@ Four modes: ModeBranch (broadest), ModeStaged, ModeStagedOnly, ModeUnstaged (nar
 
 `revise <file>` opens any file in a read-only review mode with full comment support. All lines are shown as context (no diff coloring). Starts fullscreen with diff view focused. Git-specific keys (stage/unstage/discard, mode cycling, context lines, whitespace toggle) are disabled — guarded by a single `fileReviewMode` check per key group in the Update handlers. The help overlay filters bindings via `FileReviewBindingGroups()` which uses the `GitOnly` flag on `Binding`.
 
+Navigation note (applies to all modes, not just file review): `}`/`{` (`]`/`[`) jump to the next/previous blank line (Vim-style paragraph boundary) via `nextParagraph`/`prevParagraph`. There is no dedicated hunk-to-hunk navigation — in a diff the nearest blank line usually sits at the next change, so paragraph jumping doubles as change-to-change navigation and stays consistent across modes (#122). Blank lines are flagged at build time as `lineRef.isBlank`. (`hunkStarts`/`currentHunkIndex` remain, used by hunk stage/unstage/discard.)
+
 Comments are output to stdout on exit (both in file review and git diff modes), enabling integration with Claude Code: Claude launches `revise`, user reviews and comments, comments print on close.
 
 ### Keyboard Bindings

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Press `?` inside revise to see the help overlay.
 | Key | Action |
 |-----|--------|
 | `j` / `k`, `↑` / `↓` | Move cursor |
-| `}` / `{` (`]` / `[`) | Next / prev hunk |
+| `}` / `{` (`]` / `[`) | Next / prev blank line |
 | `+` / `-` | More / fewer context lines |
 | `w` | Toggle hide whitespace |
 | `W` | Toggle soft line wrap |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Press `?` inside revise to see the help overlay.
 |-----|--------|
 | `←` (`h`) | Focus file list |
 | `→` (`l`) | Focus diff view |
-| `n` / `N` | Next / prev file |
+| `n` / `N` | Next / prev file (or search match while searching) |
 | `Tab` / `Shift+Tab` | Cycle diff mode |
 | `f` | Toggle fullscreen diff |
 | `Esc` | Back to file list |
@@ -109,6 +109,8 @@ Press `?` inside revise to see the help overlay.
 |-----|--------|
 | `j` / `k`, `↑` / `↓` | Move cursor |
 | `}` / `{` (`]` / `[`) | Next / prev blank line |
+| `/` | Search the diff (highlights matches) |
+| `n` / `N` | Next / prev search match (while searching) |
 | `+` / `-` | More / fewer context lines |
 | `w` | Toggle hide whitespace |
 | `W` | Toggle soft line wrap |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Press `?` inside revise to see the help overlay.
 | `}` / `{` (`]` / `[`) | Next / prev hunk |
 | `+` / `-` | More / fewer context lines |
 | `w` | Toggle hide whitespace |
+| `W` | Toggle soft line wrap |
 | `g` / `G` | Top / bottom |
 | `Fn+↓` / `Fn+↑` | Page down / up |
 | `Enter` / `c` | Add/edit comment on line |

--- a/internal/ui/comment.go
+++ b/internal/ui/comment.go
@@ -76,7 +76,6 @@ func fromStringMap(m map[string]string) (comments, marks) {
 	return c, mk
 }
 
-
 func (c comments) countForFile(path string) int {
 	n := 0
 	for k := range c {
@@ -127,7 +126,7 @@ func formatExport(files []git.FileDiff, c comments, m marks) string {
 		type lineEntry struct {
 			lineNum int
 			isOld   bool
-			text    string  // empty for marks
+			text    string // empty for marks
 			isMark  bool
 		}
 		var entries []lineEntry

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -18,6 +18,7 @@ type lineRef struct {
 	oldNum           int
 	lineType         git.LineType
 	isCommentDisplay bool
+	isBlank          bool // source line is empty/whitespace-only (paragraph boundary in file review)
 }
 
 // commentKey returns the storage key for a comment on this line.
@@ -301,6 +302,7 @@ func (m *diffViewModel) buildLines() {
 				newNum:   line.NewNum,
 				oldNum:   line.OldNum,
 				lineType: line.Type,
+				isBlank:  strings.TrimSpace(line.Content) == "",
 			}
 			isMarked := m.marks[ref.commentKey(m.file.Path)]
 			// width - 3 for border (2) + cursor prefix (1)
@@ -522,34 +524,58 @@ func (m *diffViewModel) hunkStarts() []int {
 	return starts
 }
 
-// nextHunk moves the cursor to the first navigable line of the next hunk.
-// If already in the last hunk, jumps to the last navigable line.
-func (m *diffViewModel) nextHunk() {
-	starts := m.hunkStarts()
-	for _, idx := range starts {
-		if idx > m.cursor {
-			m.cursor = idx
-			m.ensureCursorVisible()
-			return
+// isBlankLine reports whether the line at idx is a navigable, blank source line
+// — i.e. a Vim-style paragraph boundary that `}`/`{` jump between.
+func (m *diffViewModel) isBlankLine(idx int) bool {
+	if idx < 0 || idx >= len(m.lineRefs) {
+		return false
+	}
+	ref := m.lineRefs[idx]
+	return ref != nil && !ref.isCommentDisplay && ref.isBlank
+}
+
+// nextParagraph moves the cursor to the next blank line below it (Vim `}`).
+// If the cursor is already on a blank line, it first skips the contiguous
+// blank run, then the following paragraph, landing on the next blank line.
+// With no blank line below, it jumps to the last navigable line.
+func (m *diffViewModel) nextParagraph() {
+	i := m.cursor
+	if m.isBlankLine(i) {
+		for i < len(m.lines) && m.isBlankLine(i) {
+			i++
 		}
 	}
-	// No next hunk found — jump to last navigable line (past the last hunk).
-	m.goToLastNavigable()
+	for i < len(m.lines) && !m.isBlankLine(i) {
+		i++
+	}
+	if i < len(m.lines) {
+		m.cursor = i
+	} else {
+		m.goToLastNavigable()
+	}
 	m.ensureCursorVisible()
 }
 
-// prevHunk moves the cursor to the first navigable line of the previous hunk.
-// If the cursor is in the middle of a hunk (not on its first line), it moves
-// to the start of the current hunk instead.
-func (m *diffViewModel) prevHunk() {
-	starts := m.hunkStarts()
-	for i := len(starts) - 1; i >= 0; i-- {
-		if starts[i] < m.cursor {
-			m.cursor = starts[i]
-			m.ensureCursorVisible()
-			return
+// prevParagraph moves the cursor to the previous blank line above it (Vim `{`).
+// Mirror of nextParagraph. With no blank line above, it jumps to the top.
+func (m *diffViewModel) prevParagraph() {
+	i := m.cursor
+	if m.isBlankLine(i) {
+		for i >= 0 && m.isBlankLine(i) {
+			i--
 		}
 	}
+	for i >= 0 && !m.isBlankLine(i) {
+		i--
+	}
+	if i >= 0 {
+		m.cursor = i
+	} else {
+		// No blank line above — jump to the first navigable line (top).
+		m.cursor = 0
+		m.goToFirstNavigable()
+	}
+	m.ensureCursorVisible()
 }
 
 func (m *diffViewModel) viewHeight() int {

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/bubbles/textinput"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/justincampbell/revise/internal/git"
 )
@@ -45,6 +45,201 @@ type diffViewModel struct {
 	fileCommentInput   bool // true when editing a file-level comment (appears before first hunk)
 	textInput          textinput.Model
 	fileReviewMode     bool // true when reviewing a file (suppresses git chrome in render)
+	wrapEnabled        bool // true when soft line wrap is on (long lines wrap to multiple rows)
+}
+
+// gutterWidth returns the leading column width occupied by the line-number
+// gutter for the line at idx. Code lines have a 6-column gutter (matching the
+// gutter styles' Width(6)); non-code rows (hunk headers, comment displays,
+// blank separators) have none. Used to indent wrapped continuation rows so
+// content stays aligned under the first row.
+const gutterWidth = 6
+
+func (m diffViewModel) lineGutterWidth(idx int) int {
+	if m.isNavigable(idx) {
+		return gutterWidth
+	}
+	return 0
+}
+
+// displayRows returns the rendered display rows for the logical line at idx,
+// given the available content width and horizontal scroll offset.
+//
+// When wrap is off, a logical line is always a single display row (horizontally
+// scrolled and clipped). When wrap is on, a line wider than avail is soft-wrapped
+// onto multiple rows; continuation rows are indented past the gutter so their
+// content aligns under the first row's content.
+func (m diffViewModel) displayRows(idx, avail, hOffset int) []string {
+	line := m.lines[idx]
+	if !m.wrapEnabled {
+		if hOffset > 0 {
+			line = ansi.TruncateLeft(line, hOffset, "")
+		}
+		if ansi.StringWidth(line) > avail {
+			line = ansi.Truncate(line, avail, "")
+		}
+		return []string{line}
+	}
+	if avail < 1 || ansi.StringWidth(line) <= avail {
+		return []string{line}
+	}
+	gw := m.lineGutterWidth(idx)
+	contentAvail := avail - gw
+	if contentAvail < 1 {
+		contentAvail = 1
+	}
+	gutter := ansi.Truncate(line, gw, "")
+	content := ansi.TruncateLeft(line, gw, "")
+	segs := strings.Split(ansi.Wrap(content, contentAvail, ""), "\n")
+	indent := strings.Repeat(" ", gw)
+	rows := make([]string, len(segs))
+	for i, s := range segs {
+		if i == 0 {
+			rows[i] = gutter + s
+		} else {
+			rows[i] = indent + s
+		}
+	}
+	return rows
+}
+
+// lineRows returns how many display rows the logical line at idx occupies.
+func (m diffViewModel) lineRows(idx, avail int) int {
+	if idx < 0 || idx >= len(m.lines) {
+		return 1
+	}
+	return len(m.displayRows(idx, avail, 0))
+}
+
+// rowSpan returns the total display rows occupied by logical lines [a, b].
+func (m diffViewModel) rowSpan(a, b, avail int) int {
+	rows := 0
+	for i := a; i <= b && i < len(m.lines); i++ {
+		rows += m.lineRows(i, avail)
+	}
+	return rows
+}
+
+// lineAtRow walks forward from logical line start by targetRow display rows and
+// returns the logical line index landed on. Returns len(lines) when the target
+// is past the end (callers bounds-check).
+func (m diffViewModel) lineAtRow(start, targetRow, avail int) int {
+	if !m.wrapEnabled {
+		return start + targetRow
+	}
+	row := 0
+	for i := start; i < len(m.lines); i++ {
+		r := m.lineRows(i, avail)
+		if targetRow < row+r {
+			return i
+		}
+		row += r
+	}
+	return len(m.lines)
+}
+
+// ensureCursorVisible adjusts offset so the cursor line (including all of its
+// wrapped display rows) is visible. It scrolls up when the cursor is above the
+// viewport and down when the cursor's rows fall below it, but never scrolls
+// further than necessary. When wrap is off this reduces to the classic
+// offset = cursor - viewHeight + 1 clamp.
+func (m *diffViewModel) ensureCursorVisible() {
+	if m.cursor < m.offset {
+		m.offset = m.cursor
+		return
+	}
+	viewH := m.viewHeight()
+	avail := m.viewWidth()
+	rows := 0
+	top := m.cursor
+	for top >= 0 {
+		r := m.lineRows(top, avail)
+		if rows+r > viewH {
+			break
+		}
+		rows += r
+		top--
+	}
+	minTop := top + 1
+	if minTop < 0 {
+		minTop = 0
+	}
+	if m.offset < minTop {
+		m.offset = minTop
+	}
+}
+
+// bottomOffset returns the largest offset that keeps content filling the
+// viewport from the last line upward — the scroll position for "bottom".
+func (m *diffViewModel) bottomOffset() int {
+	viewH := m.viewHeight()
+	avail := m.viewWidth()
+	rows := 0
+	top := len(m.lines) - 1
+	for top >= 0 {
+		r := m.lineRows(top, avail)
+		if rows+r > viewH {
+			break
+		}
+		rows += r
+		top--
+	}
+	off := top + 1
+	if off < 0 {
+		off = 0
+	}
+	return off
+}
+
+// lastVisibleLine returns the index of the last logical line that fits in the
+// viewport starting at the current offset.
+func (m *diffViewModel) lastVisibleLine() int {
+	viewH := m.viewHeight()
+	avail := m.viewWidth()
+	rows := 0
+	i := m.offset
+	for i < len(m.lines) {
+		r := m.lineRows(i, avail)
+		if rows+r > viewH {
+			if i == m.offset {
+				return i // a single line taller than the viewport
+			}
+			break
+		}
+		rows += r
+		i++
+	}
+	last := i - 1
+	if last < 0 {
+		last = 0
+	}
+	return last
+}
+
+// scrollForCommentInput scrolls offset down (if needed) so the inline comment
+// input box and at least one following code row fit below the cursor within the
+// viewport. It accounts for wrapped display rows, so a tall wrapped cursor line
+// still leaves room for the box.
+func (m *diffViewModel) scrollForCommentInput() {
+	viewH := m.viewHeight()
+	avail := m.viewWidth()
+	needed := inputBoxHeight + 1 // box rows + at least one code row below
+	for m.offset < m.cursor && m.rowSpan(m.offset, m.cursor, avail)+needed > viewH {
+		m.offset++
+	}
+	if m.offset < 0 {
+		m.offset = 0
+	}
+}
+
+// toggleWrap flips soft wrap on/off and keeps the cursor visible. Horizontal
+// scroll is meaningless with wrap on, so it's reset when enabling.
+func (m *diffViewModel) toggleWrap() {
+	m.wrapEnabled = !m.wrapEnabled
+	if m.wrapEnabled {
+		m.hOffset = 0
+	}
+	m.ensureCursorVisible()
 }
 
 func newDiffViewModel() diffViewModel {
@@ -149,13 +344,7 @@ func (m *diffViewModel) rebuildLinesPreservingCursor() {
 			ref.oldNum == saved.oldNum &&
 			ref.lineType == saved.lineType {
 			m.cursor = i
-			if m.cursor < m.offset {
-				m.offset = m.cursor
-			}
-			viewH := m.viewHeight()
-			if m.cursor >= m.offset+viewH {
-				m.offset = m.cursor - viewH + 1
-			}
+			m.ensureCursorVisible()
 			return
 		}
 	}
@@ -215,10 +404,7 @@ func (m *diffViewModel) moveCursorDown(n int) {
 	for !m.isNavigable(m.cursor) && m.cursor > 0 {
 		m.cursor--
 	}
-	viewH := m.viewHeight()
-	if m.cursor >= m.offset+viewH {
-		m.offset = m.cursor - viewH + 1
-	}
+	m.ensureCursorVisible()
 }
 
 func (m *diffViewModel) moveCursorUp(n int) {
@@ -232,18 +418,15 @@ func (m *diffViewModel) moveCursorUp(n int) {
 	for !m.isNavigable(m.cursor) && m.cursor < len(m.lineRefs)-1 {
 		m.cursor++
 	}
-	if m.cursor < m.offset {
-		m.offset = m.cursor
-	}
+	m.ensureCursorVisible()
 }
 
 func (m *diffViewModel) clampCursorToView() {
-	viewH := m.viewHeight()
 	if m.cursor < m.offset {
 		m.cursor = m.offset
 	}
-	if m.cursor >= m.offset+viewH {
-		m.cursor = m.offset + viewH - 1
+	if last := m.lastVisibleLine(); m.cursor > last {
+		m.cursor = last
 	}
 	if m.cursor < 0 {
 		m.cursor = 0
@@ -260,11 +443,7 @@ func (m *diffViewModel) scrollUp(n int) {
 
 func (m *diffViewModel) scrollDown(n int) {
 	m.offset += n
-	max := len(m.lines) - m.viewHeight()
-	if max < 0 {
-		max = 0
-	}
-	if m.offset > max {
+	if max := m.bottomOffset(); m.offset > max {
 		m.offset = max
 	}
 	m.clampCursorToView()
@@ -316,11 +495,7 @@ func (m *diffViewModel) goToTop() {
 }
 
 func (m *diffViewModel) goToBottom() {
-	max := len(m.lines) - m.viewHeight()
-	if max < 0 {
-		max = 0
-	}
-	m.offset = max
+	m.offset = m.bottomOffset()
 	m.goToLastNavigable()
 }
 
@@ -354,19 +529,13 @@ func (m *diffViewModel) nextHunk() {
 	for _, idx := range starts {
 		if idx > m.cursor {
 			m.cursor = idx
-			viewH := m.viewHeight()
-			if m.cursor >= m.offset+viewH {
-				m.offset = m.cursor - viewH + 1
-			}
+			m.ensureCursorVisible()
 			return
 		}
 	}
 	// No next hunk found — jump to last navigable line (past the last hunk).
 	m.goToLastNavigable()
-	viewH := m.viewHeight()
-	if m.cursor >= m.offset+viewH {
-		m.offset = m.cursor - viewH + 1
-	}
+	m.ensureCursorVisible()
 }
 
 // prevHunk moves the cursor to the first navigable line of the previous hunk.
@@ -377,9 +546,7 @@ func (m *diffViewModel) prevHunk() {
 	for i := len(starts) - 1; i >= 0; i-- {
 		if starts[i] < m.cursor {
 			m.cursor = starts[i]
-			if m.cursor < m.offset {
-				m.offset = m.cursor
-			}
+			m.ensureCursorVisible()
 			return
 		}
 	}
@@ -394,15 +561,23 @@ func (m *diffViewModel) viewHeight() int {
 }
 
 // clickToAbsIdx converts a panel-relative click Y (0 = top border row + 1)
-// to an absolute index into lines[], accounting for any visible input box.
-// Returns -1 if the click lands inside the input box itself.
+// to an absolute index into lines[], accounting for any visible input box and
+// for wrapped display rows. Returns -1 if the click lands inside the input box.
 func (m diffViewModel) clickToAbsIdx(clickY int) int {
+	avail := m.viewWidth()
 	if !m.commentInputActive {
-		return m.offset + clickY
+		return m.lineAtRow(m.offset, clickY, avail)
 	}
-	codeAbove := m.cursor - m.offset + 1
+	if m.fileCommentInput {
+		// File-level input box sits at the top; code lines render from line 0.
+		if clickY < inputBoxHeight {
+			return -1
+		}
+		return m.lineAtRow(0, clickY-inputBoxHeight, avail)
+	}
+	codeAbove := m.rowSpan(m.offset, m.cursor, avail)
 	if clickY < codeAbove {
-		return m.offset + clickY
+		return m.lineAtRow(m.offset, clickY, avail)
 	}
 	if clickY < codeAbove+inputBoxHeight {
 		return -1 // inside the input box
@@ -412,7 +587,7 @@ func (m diffViewModel) clickToAbsIdx(clickY int) int {
 	if m.isCommentDisplayLine(nextIdx) {
 		nextIdx++ // this display line was skipped in the render
 	}
-	return nextIdx + (clickY - codeAbove - inputBoxHeight)
+	return m.lineAtRow(nextIdx, clickY-codeAbove-inputBoxHeight, avail)
 }
 
 func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p themeColors, indentSize int) string {
@@ -501,6 +676,23 @@ func (m diffViewModel) linePrefix(absIdx int, focused bool) string {
 	return " "
 }
 
+// linePrefixRow returns the leading prefix for a single display row of a
+// (possibly wrapped) logical line. The first row gets the full prefix
+// (cursor/stripe); continuation rows keep the comment/mark stripe so the
+// bookmark stays visible, but never the cursor caret.
+func (m diffViewModel) linePrefixRow(absIdx int, focused bool, rowIdx int) string {
+	if rowIdx == 0 {
+		return m.linePrefix(absIdx, focused)
+	}
+	if m.lineCommented(absIdx) {
+		return commentPrefixStyle.Render("▌")
+	}
+	if m.lineMarked(absIdx) {
+		return markPrefixStyle.Render("▌")
+	}
+	return " "
+}
+
 // lineMarked reports whether the given display line corresponds to a marked
 // source line.
 func (m diffViewModel) lineMarked(absIdx int) bool {
@@ -569,95 +761,76 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 	// Clamp a stale offset (e.g. after a resize or a shorter refreshed diff)
 	// so a scroll position from a wider state doesn't over-truncate now.
 	hOffset := m.hOffset
-	if max := m.maxHScroll(); hOffset > max {
+	if m.wrapEnabled {
+		hOffset = 0 // horizontal scroll is meaningless with wrap on
+	} else if max := m.maxHScroll(); hOffset > max {
 		hOffset = max
 	}
 
-	renderLine := func(absIdx int) string {
-		line := m.lines[absIdx]
-		if hOffset > 0 {
-			line = ansi.TruncateLeft(line, hOffset, "")
+	// rowsFor returns the prefixed display rows for a logical line — one row
+	// when wrap is off, possibly several when a wrapped line spans the width.
+	rowsFor := func(absIdx int) []string {
+		body := m.displayRows(absIdx, maxWidth, hOffset)
+		out := make([]string, len(body))
+		for i, s := range body {
+			out[i] = m.linePrefixRow(absIdx, focused, i) + s
 		}
-		if ansi.StringWidth(line) > maxWidth {
-			line = ansi.Truncate(line, maxWidth, "")
-		}
-		return m.linePrefix(absIdx, focused) + line
+		return out
 	}
 
+	// appendRows draws logical lines starting at `from` until the viewport has
+	// `limit` rows (or the lines run out), returning the rows used. Each wrapped
+	// continuation row counts toward the limit.
 	var renderedLines []string
-	if len(m.lines) == 0 {
-		renderedLines = append(renderedLines, "No changes to display")
+	appendRows := func(from, limit int) int {
+		used := 0
+		for absIdx := from; absIdx < len(m.lines) && used < limit; absIdx++ {
+			for _, r := range rowsFor(absIdx) {
+				if used >= limit {
+					break
+				}
+				renderedLines = append(renderedLines, r)
+				used++
+			}
+		}
+		return used
 	}
 
-	if m.commentInputActive && m.fileCommentInput && len(m.lines) > 0 {
-		// File-level comment: input box appears before any code lines.
+	inputBoxView := func() string {
 		inputWidth := m.width - 4
 		if inputWidth < 10 {
 			inputWidth = 10
 		}
 		m.textInput.Width = inputWidth - 4
-		inputBox := commentInputStyle.Width(inputWidth).Render(m.textInput.View())
-		renderedLines = append(renderedLines, inputBox)
+		return commentInputStyle.Width(inputWidth).Render(m.textInput.View())
+	}
 
-		codeBelow := viewH - inputBoxHeight
-		if codeBelow < 0 {
-			codeBelow = 0
+	if len(m.lines) == 0 {
+		renderedLines = append(renderedLines, "No changes to display")
+	} else if m.commentInputActive && m.fileCommentInput {
+		// File-level comment: input box appears before any code lines.
+		renderedLines = append(renderedLines, inputBoxView())
+		appendRows(0, viewH-inputBoxHeight)
+	} else if m.commentInputActive {
+		// Inline comment: render lines [offset..cursor], then the input box,
+		// then the lines after the cursor (skipping the existing comment
+		// display row, which the box replaces while editing).
+		used := 0
+		for absIdx := m.offset; absIdx <= m.cursor && absIdx < len(m.lines); absIdx++ {
+			for _, r := range rowsFor(absIdx) {
+				renderedLines = append(renderedLines, r)
+				used++
+			}
 		}
-		end := codeBelow
-		if end > len(m.lines) {
-			end = len(m.lines)
-		}
-		for absIdx := 0; absIdx < end; absIdx++ {
-			renderedLines = append(renderedLines, renderLine(absIdx))
-		}
-	} else if m.commentInputActive && len(m.lines) > 0 {
-		codeAbove := m.cursor - m.offset + 1
-		if codeAbove < 0 {
-			codeAbove = 0
-		}
-		end := m.offset + codeAbove
-		if end > len(m.lines) {
-			end = len(m.lines)
-		}
-		for absIdx := m.offset; absIdx < end; absIdx++ {
-			renderedLines = append(renderedLines, renderLine(absIdx))
-		}
-
-		// Skip any existing comment display line for this code line —
-		// the input box replaces it while editing.
 		nextIdx := m.cursor + 1
 		if m.isCommentDisplayLine(nextIdx) {
 			nextIdx++
 		}
-
-		// Inline input box.
-		inputWidth := m.width - 4
-		if inputWidth < 10 {
-			inputWidth = 10
-		}
-		m.textInput.Width = inputWidth - 4
-		inputBox := commentInputStyle.Width(inputWidth).Render(m.textInput.View())
-		renderedLines = append(renderedLines, inputBox)
-
-		codeBelow := viewH - inputBoxHeight - codeAbove
-		if codeBelow < 0 {
-			codeBelow = 0
-		}
-		endAfter := nextIdx + codeBelow
-		if endAfter > len(m.lines) {
-			endAfter = len(m.lines)
-		}
-		for absIdx := nextIdx; absIdx < endAfter; absIdx++ {
-			renderedLines = append(renderedLines, renderLine(absIdx))
-		}
-	} else if len(m.lines) > 0 {
-		end := m.offset + viewH
-		if end > len(m.lines) {
-			end = len(m.lines)
-		}
-		for absIdx := m.offset; absIdx < end; absIdx++ {
-			renderedLines = append(renderedLines, renderLine(absIdx))
-		}
+		renderedLines = append(renderedLines, inputBoxView())
+		used += inputBoxHeight
+		appendRows(nextIdx, viewH-used)
+	} else {
+		appendRows(m.offset, viewH)
 	}
 
 	added, removed := 0, 0
@@ -682,6 +855,9 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 		}
 		if slider != "" {
 			rendered = setBorderTitleCentered(rendered, fileStyle.Render(" "+slider+" "), focused)
+		}
+		if m.wrapEnabled {
+			rendered = setBorderBottomRight(rendered, modeActiveStyle.Render(" Wrap "), focused)
 		}
 		return rendered
 	}
@@ -711,13 +887,18 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 		ctxLabel = modeActiveStyle.Render(ctxText)
 	}
 	rendered = setBorderBottomLeft(rendered, ctxLabel, focused)
-	if hideWhitespace {
-		wsLabel := modeActiveStyle.Render(" Whitespace hidden ")
-		rendered = setBorderBottomRight(rendered, wsLabel, focused)
-	} else {
-		wsLabel := statusBarStyle.Render(" Whitespace ")
-		rendered = setBorderBottomRight(rendered, wsLabel, focused)
+	// Bottom-right footer: optional " Wrap " indicator followed by the
+	// whitespace indicator. Both are right-aligned as one label.
+	right := ""
+	if m.wrapEnabled {
+		right += modeActiveStyle.Render(" Wrap ")
 	}
+	if hideWhitespace {
+		right += modeActiveStyle.Render(" Whitespace hidden ")
+	} else {
+		right += statusBarStyle.Render(" Whitespace ")
+	}
+	rendered = setBorderBottomRight(rendered, right, focused)
 	return rendered
 }
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -18,7 +19,8 @@ type lineRef struct {
 	oldNum           int
 	lineType         git.LineType
 	isCommentDisplay bool
-	isBlank          bool // source line is empty/whitespace-only (paragraph boundary in file review)
+	isBlank          bool   // source line is empty/whitespace-only (paragraph boundary in file review)
+	content          string // plain source text, used for incremental search matching
 }
 
 // commentKey returns the storage key for a comment on this line.
@@ -47,6 +49,16 @@ type diffViewModel struct {
 	textInput          textinput.Model
 	fileReviewMode     bool // true when reviewing a file (suppresses git chrome in render)
 	wrapEnabled        bool // true when soft line wrap is on (long lines wrap to multiple rows)
+
+	// Incremental search (#72). searchQuery drives both highlighting (in
+	// buildLines/renderDiffLine) and match navigation. searchMatches holds
+	// the navigable line indices that contain the query; searchIdx is the
+	// position within searchMatches of the "current" match (-1 when none).
+	searchInput   textinput.Model
+	searchQuery   string
+	searchMatches []int
+	searchIdx     int
+	searchOrigin  int // cursor when search started, so typing jumps to the nearest match forward
 }
 
 // gutterWidth returns the leading column width occupied by the line-number
@@ -247,9 +259,17 @@ func newDiffViewModel() diffViewModel {
 	ti := textinput.New()
 	ti.Placeholder = "Add a comment…"
 	ti.CharLimit = 500
+
+	si := textinput.New()
+	si.Prompt = "" // the "/" prompt is rendered by the status bar
+	si.Placeholder = ""
+	si.CharLimit = 200
+
 	return diffViewModel{
-		comments:  make(comments),
-		textInput: ti,
+		comments:    make(comments),
+		textInput:   ti,
+		searchInput: si,
+		searchIdx:   -1,
 	}
 }
 
@@ -258,6 +278,10 @@ func (m *diffViewModel) setFile(f *git.FileDiff) {
 	m.cursor = 0
 	m.offset = 0
 	m.hOffset = 0
+	// Search is scoped to the current file; switching files clears it.
+	m.searchQuery = ""
+	m.searchMatches = nil
+	m.searchIdx = -1
 	m.buildLines()
 	m.goToFirstNavigable()
 }
@@ -303,6 +327,7 @@ func (m *diffViewModel) buildLines() {
 				oldNum:   line.OldNum,
 				lineType: line.Type,
 				isBlank:  strings.TrimSpace(line.Content) == "",
+				content:  line.Content,
 			}
 			isMarked := m.marks[ref.commentKey(m.file.Path)]
 			// width - 3 for border (2) + cursor prefix (1)
@@ -310,7 +335,7 @@ func (m *diffViewModel) buildLines() {
 			if fillWidth < 1 {
 				fillWidth = 1
 			}
-			add(renderDiffLine(line, isMarked, fillWidth, m.file.Path, p, indentSize), ref)
+			add(renderDiffLine(line, isMarked, fillWidth, m.file.Path, p, indentSize, m.searchQuery), ref)
 
 			// If this code line has a saved comment, add a display line below it.
 			key := ref.commentKey(m.file.Path)
@@ -586,6 +611,234 @@ func (m *diffViewModel) viewHeight() int {
 	return h
 }
 
+// matchRanges returns the rune-index ranges of every case-insensitive
+// occurrence of query within content. Ranges are [start, end) in runes so
+// callers can slice []rune(content) directly. Returns nil for an empty query
+// or no matches.
+func matchRanges(content, query string) [][2]int {
+	q := []rune(query)
+	if len(q) == 0 {
+		return nil
+	}
+	c := []rune(content)
+	lc := make([]rune, len(c))
+	for i, r := range c {
+		lc[i] = unicode.ToLower(r)
+	}
+	lq := make([]rune, len(q))
+	for i, r := range q {
+		lq[i] = unicode.ToLower(r)
+	}
+
+	var ranges [][2]int
+	for i := 0; i+len(lq) <= len(lc); {
+		matched := true
+		for j := range lq {
+			if lc[i+j] != lq[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			ranges = append(ranges, [2]int{i, i + len(lq)})
+			i += len(lq)
+		} else {
+			i++
+		}
+	}
+	return ranges
+}
+
+// matchColumnRanges converts the rune-index match ranges of query within
+// content into visual-column ranges (accounting for wide runes), so callers
+// can slice an already-styled string by column.
+func matchColumnRanges(content, query string) [][2]int {
+	rr := matchRanges(content, query)
+	if rr == nil {
+		return nil
+	}
+	runes := []rune(content)
+	cols := make([][2]int, len(rr))
+	for i, r := range rr {
+		cols[i] = [2]int{
+			ansi.StringWidth(string(runes[:r[0]])),
+			ansi.StringWidth(string(runes[:r[1]])),
+		}
+	}
+	return cols
+}
+
+// overlaySearchHighlight re-styles the given visual-column ranges of an
+// already-styled string with searchMatchStyle, leaving the surrounding styling
+// (syntax highlight, diff background) intact. Column ranges are [start, end)
+// and must be ascending and non-overlapping.
+func overlaySearchHighlight(styled string, colRanges [][2]int) string {
+	var b strings.Builder
+	prev := 0
+	for _, r := range colRanges {
+		cs, ce := r[0], r[1]
+		if cs < prev {
+			cs = prev
+		}
+		if ce <= cs {
+			continue
+		}
+		if cs > prev {
+			b.WriteString(clipCols(styled, prev, cs))
+		}
+		// Strip the matched slice's own styling, then apply the match style.
+		b.WriteString(searchMatchStyle.Render(ansi.Strip(clipCols(styled, cs, ce))))
+		prev = ce
+	}
+	b.WriteString(ansi.TruncateLeft(styled, prev, ""))
+	return b.String()
+}
+
+// clipCols returns the visual columns [from, to) of a styled string, preserving
+// ANSI styling at the cut points.
+func clipCols(styled string, from, to int) string {
+	if from > 0 {
+		styled = ansi.TruncateLeft(styled, from, "")
+	}
+	return ansi.Truncate(styled, to-from, "")
+}
+
+// lineContainsQuery reports whether content contains query (case-insensitive).
+func lineContainsQuery(content, query string) bool {
+	if query == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(content), strings.ToLower(query))
+}
+
+// computeSearchMatches rebuilds searchMatches from the current searchQuery,
+// scanning navigable code lines. searchIdx is reset to -1 when there are no
+// matches and clamped into range otherwise.
+func (m *diffViewModel) computeSearchMatches() {
+	m.searchMatches = nil
+	if m.searchQuery == "" {
+		m.searchIdx = -1
+		return
+	}
+	for i := range m.lineRefs {
+		if !m.isNavigable(i) {
+			continue
+		}
+		if lineContainsQuery(m.lineRefs[i].content, m.searchQuery) {
+			m.searchMatches = append(m.searchMatches, i)
+		}
+	}
+	if len(m.searchMatches) == 0 {
+		m.searchIdx = -1
+	} else if m.searchIdx < 0 || m.searchIdx >= len(m.searchMatches) {
+		m.searchIdx = 0
+	}
+}
+
+// startSearch begins an incremental search. searchOrigin records the cursor so
+// typing jumps to the nearest match at or after it.
+func (m *diffViewModel) startSearch() {
+	m.searchOrigin = m.cursor
+	m.searchQuery = ""
+	m.searchMatches = nil
+	m.searchIdx = -1
+	m.searchInput.SetValue("")
+	m.searchInput.Focus()
+}
+
+// setSearch updates the active query (incremental: called on each keystroke),
+// recomputes highlights and matches, and moves the cursor to the first match at
+// or after searchOrigin (wrapping). With no matches, the cursor stays put.
+func (m *diffViewModel) setSearch(query string) {
+	m.searchQuery = query
+	m.buildLines() // re-render with the new highlight
+	m.computeSearchMatches()
+	if len(m.searchMatches) == 0 {
+		return
+	}
+	m.searchIdx = 0
+	for i, idx := range m.searchMatches {
+		if idx >= m.searchOrigin {
+			m.searchIdx = i
+			break
+		}
+	}
+	m.cursor = m.searchMatches[m.searchIdx]
+	m.ensureCursorVisible()
+	m.ensureMatchVisible()
+}
+
+// clearSearch drops the active search and removes highlighting.
+func (m *diffViewModel) clearSearch() {
+	m.searchQuery = ""
+	m.searchMatches = nil
+	m.searchIdx = -1
+	m.searchInput.Blur()
+	m.buildLines()
+}
+
+// nextMatch moves the cursor to the next match, wrapping past the end.
+func (m *diffViewModel) nextMatch() {
+	if len(m.searchMatches) == 0 {
+		return
+	}
+	m.searchIdx = (m.searchIdx + 1) % len(m.searchMatches)
+	m.cursor = m.searchMatches[m.searchIdx]
+	m.ensureCursorVisible()
+	m.ensureMatchVisible()
+}
+
+// prevMatch moves the cursor to the previous match, wrapping past the start.
+func (m *diffViewModel) prevMatch() {
+	if len(m.searchMatches) == 0 {
+		return
+	}
+	m.searchIdx = (m.searchIdx - 1 + len(m.searchMatches)) % len(m.searchMatches)
+	m.cursor = m.searchMatches[m.searchIdx]
+	m.ensureCursorVisible()
+	m.ensureMatchVisible()
+}
+
+// ensureMatchVisible scrolls horizontally (when wrap is off) so the first
+// occurrence of the query on the current match line is within the viewport. A
+// small margin keeps a little context around the match.
+func (m *diffViewModel) ensureMatchVisible() {
+	if m.wrapEnabled || m.searchQuery == "" {
+		return
+	}
+	if m.searchIdx < 0 || m.searchIdx >= len(m.searchMatches) {
+		return
+	}
+	idx := m.searchMatches[m.searchIdx]
+	if !m.isNavigable(idx) {
+		return
+	}
+	cols := matchColumnRanges(m.lineRefs[idx].content, m.searchQuery)
+	if len(cols) == 0 {
+		return
+	}
+	avail := m.viewWidth()
+	if avail < 1 {
+		return
+	}
+	// Columns are within the content; the rendered line prepends a gutter.
+	start := gutterWidth + cols[0][0]
+	end := gutterWidth + cols[0][1]
+	margin := hScrollStep
+	switch {
+	case start < m.hOffset:
+		m.hOffset = start - margin
+	case end > m.hOffset+avail:
+		m.hOffset = end - avail + margin
+	}
+	if m.hOffset < 0 {
+		m.hOffset = 0
+	}
+	if max := m.maxHScroll(); m.hOffset > max {
+		m.hOffset = max
+	}
+}
+
 // clickToAbsIdx converts a panel-relative click Y (0 = top border row + 1)
 // to an absolute index into lines[], accounting for any visible input box and
 // for wrapped display rows. Returns -1 if the click lands inside the input box.
@@ -616,7 +869,7 @@ func (m diffViewModel) clickToAbsIdx(clickY int) int {
 	return m.lineAtRow(nextIdx, clickY-codeAbove-inputBoxHeight, avail)
 }
 
-func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p themeColors, indentSize int) string {
+func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p themeColors, indentSize int, query string) string {
 	gutter := git.FormatGutter(l)
 	if marked {
 		content := l.Content
@@ -636,24 +889,44 @@ func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p t
 		}
 		return l.Content
 	}
+
+	// Render the content with normal styling (syntax highlight when available,
+	// otherwise the base diff-line style), then overlay search highlighting on
+	// just the matched columns so the rest of the line keeps its colors.
+	var gutterStyle lipgloss.Style
+	var content string
 	switch l.Type {
 	case git.LineAdded:
+		gutterStyle = addedGutterStyle
 		if highlighted, ok := highlightLine(l.Content, filePath, p.addedBg, indentSize); ok {
-			return addedGutterStyle.Render(gutter) + highlighted
+			content = highlighted
+		} else {
+			content = addedStyle.Render(addIndentGuides(l.Content, indentSize, p.addedBg))
 		}
-		return addedGutterStyle.Render(gutter) + addedStyle.Render(addIndentGuides(l.Content, indentSize, p.addedBg))
 	case git.LineRemoved:
+		gutterStyle = removedGutterStyle
 		if highlighted, ok := highlightLine(l.Content, filePath, p.removedBg, indentSize); ok {
-			return removedGutterStyle.Render(gutter) + highlighted
+			content = highlighted
+		} else {
+			content = removedStyle.Render(addIndentGuides(l.Content, indentSize, p.removedBg))
 		}
-		return removedGutterStyle.Render(gutter) + removedStyle.Render(addIndentGuides(l.Content, indentSize, p.removedBg))
 	case git.LineContext:
+		gutterStyle = contextGutterStyle
 		if highlighted, ok := highlightLine(l.Content, filePath, nil, indentSize); ok {
-			return contextGutterStyle.Render(gutter) + highlighted
+			content = highlighted
+		} else {
+			content = contextStyle.Render(addIndentGuides(l.Content, indentSize, nil))
 		}
-		return contextGutterStyle.Render(gutter) + contextStyle.Render(addIndentGuides(l.Content, indentSize, nil))
+	default:
+		return l.Content
 	}
-	return l.Content
+
+	if query != "" {
+		if cols := matchColumnRanges(l.Content, query); len(cols) > 0 {
+			content = overlaySearchHighlight(content, cols)
+		}
+	}
+	return gutterStyle.Render(gutter) + content
 }
 
 func renderHunkHeader(h git.Hunk) string {

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -382,7 +382,6 @@ func TestRenderHunkHeader_EmptyContext_StillShowsTag(t *testing.T) {
 	assert.Contains(t, got, "[staged]")
 }
 
-
 func TestDiffView_TitleInBorder(t *testing.T) {
 	m := newDiffViewModel()
 	m.width = 40
@@ -542,69 +541,6 @@ func makeDiffViewModelWithHunks() diffViewModel {
 	return m
 }
 
-func TestNextHunk_MovesToFirstLineOfNextHunk(t *testing.T) {
-	m := makeDiffViewModelWithHunks()
-	// Cursor starts on first navigable line of hunk 0
-	assert.Equal(t, 1, m.lineRefs[m.cursor].newNum) // ctx1, newNum=1
-	m.nextHunk()
-	// Should be on first code line of hunk 1
-	assert.Equal(t, 11, m.lineRefs[m.cursor].newNum) // ctx3, newNum=11
-}
-
-func TestNextHunk_FromMiddleOfHunk(t *testing.T) {
-	m := makeDiffViewModelWithHunks()
-	m.moveCursorDown(1) // move to added1
-	assert.Equal(t, 2, m.lineRefs[m.cursor].newNum)
-	m.nextHunk()
-	assert.Equal(t, 11, m.lineRefs[m.cursor].newNum) // first line of hunk 1
-}
-
-func TestNextHunk_FromLastHunk_JumpsToEnd(t *testing.T) {
-	m := makeDiffViewModelWithHunks()
-	// Go to last hunk
-	m.nextHunk()
-	m.nextHunk()
-	assert.Equal(t, 22, m.lineRefs[m.cursor].newNum) // first line of hunk 2
-	m.nextHunk()
-	// Should jump to the last navigable line (past the last hunk)
-	assert.Equal(t, 23, m.lineRefs[m.cursor].newNum)
-}
-
-func TestPrevHunk_MovesToFirstLineOfPrevHunk(t *testing.T) {
-	m := makeDiffViewModelWithHunks()
-	m.nextHunk()
-	m.nextHunk()
-	assert.Equal(t, 22, m.lineRefs[m.cursor].newNum)
-	m.prevHunk()
-	assert.Equal(t, 11, m.lineRefs[m.cursor].newNum)
-}
-
-func TestPrevHunk_FromFirstHunk_StaysAtTop(t *testing.T) {
-	m := makeDiffViewModelWithHunks()
-	m.prevHunk()
-	assert.Equal(t, 1, m.lineRefs[m.cursor].newNum) // still on first line
-}
-
-func TestNextHunk_FromLastHunk_JumpsPastToLastLine(t *testing.T) {
-	m := makeDiffViewModelWithHunks()
-	// Go to last hunk
-	m.nextHunk()
-	m.nextHunk()
-	assert.Equal(t, 22, m.lineRefs[m.cursor].newNum) // first line of hunk 2
-	m.nextHunk()
-	// Should jump to the last navigable line (past the last hunk)
-	assert.Equal(t, 23, m.lineRefs[m.cursor].newNum) // added3, last navigable line
-}
-
-func TestPrevHunk_FromFirstLineOfFirstHunk_JumpsToTop(t *testing.T) {
-	m := makeDiffViewModelWithHunks()
-	// Cursor is already on first navigable line (first line of first hunk)
-	assert.Equal(t, 1, m.lineRefs[m.cursor].newNum)
-	// prevHunk should be a no-op since we're already at the start of the first hunk
-	m.prevHunk()
-	assert.Equal(t, 1, m.lineRefs[m.cursor].newNum)
-}
-
 func TestCurrentHunkIndex_FirstHunk(t *testing.T) {
 	m := makeDiffViewModelWithHunks()
 	// Cursor starts on first navigable line of hunk 0
@@ -613,20 +549,19 @@ func TestCurrentHunkIndex_FirstHunk(t *testing.T) {
 
 func TestCurrentHunkIndex_SecondHunk(t *testing.T) {
 	m := makeDiffViewModelWithHunks()
-	m.nextHunk()
+	m.cursor = m.hunkStarts()[1]
 	assert.Equal(t, 1, m.currentHunkIndex())
 }
 
 func TestCurrentHunkIndex_ThirdHunk(t *testing.T) {
 	m := makeDiffViewModelWithHunks()
-	m.nextHunk()
-	m.nextHunk()
+	m.cursor = m.hunkStarts()[2]
 	assert.Equal(t, 2, m.currentHunkIndex())
 }
 
 func TestCurrentHunkIndex_MiddleOfHunk(t *testing.T) {
 	m := makeDiffViewModelWithHunks()
-	m.nextHunk()
+	m.cursor = m.hunkStarts()[1]
 	m.moveCursorDown(2) // middle of hunk 1
 	assert.Equal(t, 1, m.currentHunkIndex())
 }
@@ -635,16 +570,6 @@ func TestCurrentHunkIndex_NoFile(t *testing.T) {
 	m := newDiffViewModel()
 	m.height = 10
 	assert.Equal(t, -1, m.currentHunkIndex())
-}
-
-func TestPrevHunk_FromMiddleOfHunk_GoesToStartOfCurrentHunk(t *testing.T) {
-	m := makeDiffViewModelWithHunks()
-	m.nextHunk()            // go to hunk 1
-	m.moveCursorDown(2)     // move into middle of hunk 1
-	assert.Equal(t, 12, m.lineRefs[m.cursor].newNum)
-	m.prevHunk()
-	// Should go to start of hunk 1 (since we're in the middle of it)
-	assert.Equal(t, 11, m.lineRefs[m.cursor].newNum)
 }
 
 // makePlainBottomBorder builds a minimal two-line "rendered" string that
@@ -680,7 +605,7 @@ func TestSetBorderBottomCounts_SlashColumnFixed(t *testing.T) {
 	}
 
 	rendered := makePlainBottomBorder(paneWidth)
-	contentWidth := paneWidth - 2 // minus corners
+	contentWidth := paneWidth - 2          // minus corners
 	expectedSlashCol := 1 + contentWidth/2 // 1 for ╰ corner
 
 	var slashCols []int

--- a/internal/ui/filelist_test.go
+++ b/internal/ui/filelist_test.go
@@ -121,9 +121,9 @@ func TestFileTotals(t *testing.T) {
 
 func TestFileStagingSources(t *testing.T) {
 	tests := []struct {
-		name    string
-		hunks   []git.Hunk
-		want    stagingSources
+		name  string
+		hunks []git.Hunk
+		want  stagingSources
 	}{
 		{
 			name:  "staged only",

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -39,7 +39,7 @@ var allBindings = []BindingGroup{
 	{"Diff View", []Binding{
 		{Key: "←/→ (h/l)", Desc: "Scroll horizontally"},
 		{Key: "j/k, ↑/↓", Desc: "Move cursor"},
-		{Key: "}/{ (]/[)", Desc: "Next/prev hunk"},
+		{Key: "}/{ (]/[)", Desc: "Next/prev blank line"},
 		{Key: "+/-", Desc: "More/fewer context lines", GitOnly: true},
 		{Key: "w", Desc: "Toggle hide whitespace", GitOnly: true},
 		{Key: "W", Desc: "Toggle soft line wrap"},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -42,6 +42,7 @@ var allBindings = []BindingGroup{
 		{Key: "}/{ (]/[)", Desc: "Next/prev hunk"},
 		{Key: "+/-", Desc: "More/fewer context lines", GitOnly: true},
 		{Key: "w", Desc: "Toggle hide whitespace", GitOnly: true},
+		{Key: "W", Desc: "Toggle soft line wrap"},
 		{Key: "g/G", Desc: "Top/bottom"},
 		{Key: "Fn+↓/↑", Desc: "Page down/up"},
 		{Key: "Enter/c", Desc: "Add/edit comment on line"},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -52,6 +52,11 @@ var allBindings = []BindingGroup{
 		{Key: "u/U", Desc: "Unstage hunk/file", GitOnly: true},
 		{Key: "D", Desc: "Discard hunk", GitOnly: true},
 	}},
+	{"Search", []Binding{
+		{Key: "/", Desc: "Search in diff"},
+		{Key: "n/N", Desc: "Next/prev match"},
+		{Key: "Esc", Desc: "Clear search"},
+	}},
 	{"Global", []Binding{
 		{Key: "e", Desc: "Export comments to clipboard"},
 		{Key: "E", Desc: "Open current file at cursor line in $VISUAL/$EDITOR"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"charm.land/lipgloss/v2"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 	commentstore "github.com/justincampbell/revise/internal/comments"
 	"github.com/justincampbell/revise/internal/editor"
@@ -98,10 +98,10 @@ type debugTickMsg struct{}
 type DiffMode int
 
 const (
-	ModeBranch    DiffMode = iota // committed + staged + unstaged + untracked (broadest, feature branch only)
-	ModeStaged                    // staged + unstaged + untracked
-	ModeStagedOnly                // staged only (no unstaged or untracked)
-	ModeUnstaged                  // unstaged + untracked only (narrowest)
+	ModeBranch     DiffMode = iota // committed + staged + unstaged + untracked (broadest, feature branch only)
+	ModeStaged                     // staged + unstaged + untracked
+	ModeStagedOnly                 // staged only (no unstaged or untracked)
+	ModeUnstaged                   // unstaged + untracked only (narrowest)
 )
 
 type focusPanel int
@@ -168,9 +168,9 @@ type Model struct {
 	fsWatcher            *fswatch.Watcher // nil if disabled or init failed
 	debug                bool             // true in --debug mode; renders refresh debug strip
 
-	currentVersion string              // version string from build
-	updateInfo     *update.UpdateInfo  // populated after update check
-	updating       bool                // true while downloading update
+	currentVersion string             // version string from build
+	updateInfo     *update.UpdateInfo // populated after update check
+	updating       bool               // true while downloading update
 
 	fileReviewMode bool   // true when reviewing a file (not a git diff)
 	fileReviewPath string // filename shown in status bar
@@ -358,6 +358,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "?":
 			m.showHelp = !m.showHelp
+			return m, nil
+
+		// Soft wrap toggle — works in both git diff and file review mode.
+		// No diff reload needed; it's purely a rendering change.
+		case "W", "alt+z":
+			m.diffView.toggleWrap()
 			return m, nil
 
 		case "right", "l":
@@ -1026,14 +1032,7 @@ func (m *Model) startCommentInput() {
 	m.diffView.textInput.Focus()
 
 	// Scroll so there's room below the cursor for the input box.
-	viewH := m.diffView.viewHeight()
-	minRoom := inputBoxHeight + 1 // rows needed below cursor
-	if m.diffView.cursor > m.diffView.offset+viewH-minRoom {
-		m.diffView.offset = m.diffView.cursor - viewH + minRoom
-		if m.diffView.offset < 0 {
-			m.diffView.offset = 0
-		}
-	}
+	m.diffView.scrollForCommentInput()
 
 	m.commentInputActive = true
 	m.diffView.commentInputActive = true

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -140,6 +140,7 @@ type Model struct {
 	storePath          string // path to JSON file for comment persistence
 	commentInputActive bool
 	commentTarget      commentKey
+	searchActive       bool // true while the incremental-search input box is open
 	statusMsg          string
 
 	confirmDiscard    bool    // waiting for confirmation to discard
@@ -325,6 +326,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateCommentInput(msg)
 		}
 
+		if m.searchActive {
+			return m.updateSearchInput(msg)
+		}
+
 		if m.confirmDiscard {
 			return m.updateConfirmDiscard(msg)
 		}
@@ -352,6 +357,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		// Esc clears an active (committed) search before any other Esc
+		// behavior (back-to-file-list / exit-fullscreen) takes over.
+		if msg.String() == "esc" && m.diffView.searchQuery != "" {
+			m.diffView.clearSearch()
+			return m, nil
+		}
+
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return m, tea.Quit
@@ -364,6 +376,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// No diff reload needed; it's purely a rendering change.
 		case "W", "alt+z":
 			m.diffView.toggleWrap()
+			return m, nil
+
+		// Incremental search in the diff view — works in both modes.
+		case "/":
+			m.startSearch()
 			return m, nil
 
 		case "right", "l":
@@ -440,11 +457,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-		// File list navigation (always works)
+		// n/N navigate search matches while a search is active, otherwise
+		// they move between files (the default).
 		case "n":
+			if m.diffView.searchQuery != "" {
+				m.diffView.nextMatch()
+				return m, nil
+			}
 			m.nextFile()
 			return m, nil
 		case "N":
+			if m.diffView.searchQuery != "" {
+				m.diffView.prevMatch()
+				return m, nil
+			}
 			m.prevFile()
 			return m, nil
 
@@ -952,6 +978,47 @@ func (m Model) updateDiffView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+// startSearch opens the incremental search box, focusing the diff view so the
+// cursor and match highlights are visible while typing.
+func (m *Model) startSearch() {
+	m.focus = focusDiffView
+	m.searchActive = true
+	m.diffView.startSearch()
+}
+
+// updateSearchInput handles keys while the search box is open. Typing filters
+// incrementally; Enter commits (matches stay highlighted, n/N navigate them);
+// Esc cancels and clears.
+func (m Model) updateSearchInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		m.searchActive = false
+		m.diffView.searchInput.Blur()
+		if m.diffView.searchQuery != "" && len(m.diffView.searchMatches) == 0 {
+			m.statusMsg = "No matches for \"" + m.diffView.searchQuery + "\""
+			return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearStatusMsg{} })
+		}
+		return m, nil
+	case "esc":
+		m.searchActive = false
+		m.diffView.clearSearch()
+		return m, nil
+	case "backspace":
+		// Backspace on an already-empty box exits search (like less/vim).
+		if m.diffView.searchInput.Value() == "" {
+			m.searchActive = false
+			m.diffView.clearSearch()
+			return m, nil
+		}
+		fallthrough
+	default:
+		var cmd tea.Cmd
+		m.diffView.searchInput, cmd = m.diffView.searchInput.Update(msg)
+		m.diffView.setSearch(m.diffView.searchInput.Value())
+		return m, cmd
+	}
 }
 
 func (m Model) updateCommentInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -1680,11 +1747,42 @@ func (m Model) renderStatusBar() string {
 		return statusBarStyle.Width(m.width).Render(hint)
 	}
 
+	helpHint := helpKeyStyle.Render("?") + statusBarStyle.Render(" help")
+
+	// While the search box is open, the status bar is the search prompt:
+	// "/<query>  N/M" (or "no matches" once a non-empty query has none).
+	if m.searchActive {
+		prompt := helpKeyStyle.Render("/") + m.diffView.searchInput.View()
+		info := ""
+		if m.diffView.searchQuery != "" {
+			if n := len(m.diffView.searchMatches); n == 0 {
+				info = statusBarStyle.Render("  no matches")
+			} else {
+				info = statusBarStyle.Render(fmt.Sprintf("  %d/%d", m.diffView.searchIdx+1, n))
+			}
+		}
+		return statusBarStyle.Width(m.width).Render(prompt + info)
+	}
+
 	if m.statusMsg != "" {
 		return statusBarStyle.Width(m.width).Render(m.statusMsg)
 	}
 
-	helpHint := helpKeyStyle.Render("?") + statusBarStyle.Render(" help")
+	// A committed search keeps a compact nav hint in the status bar until
+	// it's cleared with Esc.
+	if m.diffView.searchQuery != "" {
+		n := len(m.diffView.searchMatches)
+		if n == 0 {
+			hint := statusBarStyle.Render("/"+m.diffView.searchQuery+" — no matches  ") + helpHint
+			return statusBarStyle.Width(m.width).Render(hint)
+		}
+		hint := helpKeyStyle.Render("/") + statusBarStyle.Render(m.diffView.searchQuery+" ") +
+			statusBarStyle.Render(fmt.Sprintf("%d/%d  ", m.diffView.searchIdx+1, n)) +
+			helpKeyStyle.Render("n") + statusBarStyle.Render("/") + helpKeyStyle.Render("N") +
+			statusBarStyle.Render(" next/prev  ") +
+			helpKeyStyle.Render("Esc") + statusBarStyle.Render(" clear  ") + helpHint
+		return statusBarStyle.Width(m.width).Render(hint)
+	}
 
 	if m.noCommits {
 		hint := statusBarStyle.Render("No commits yet — staged and untracked files only  ") + helpHint

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -912,9 +912,9 @@ func (m Model) updateDiffView(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "pgup":
 		m.diffView.pageUp()
 	case "}", "]":
-		m.diffView.nextHunk()
+		m.diffView.nextParagraph()
 	case "{", "[":
-		m.diffView.prevHunk()
+		m.diffView.prevParagraph()
 	case "c", "enter":
 		if m.diffView.cursorRef() != nil {
 			m.startCommentInput()

--- a/internal/ui/paragraph_test.go
+++ b/internal/ui/paragraph_test.go
@@ -1,0 +1,118 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/justincampbell/revise/internal/git"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeParagraphModel builds a file-review-style model whose source lines form
+// three paragraphs separated by blank lines:
+//
+//	0: para1 line a
+//	1: para1 line b
+//	2: (blank)
+//	3: para2 line a
+//	4: (blank)
+//	5: para3 line a
+//	6: para3 line b
+//	7: (trailing separator, non-navigable)
+func makeParagraphModel(t *testing.T) diffViewModel {
+	t.Helper()
+	m := newDiffViewModel()
+	m.height = 20
+	m.fileReviewMode = true
+	m.file = &git.FileDiff{
+		Path: "doc.md",
+		Hunks: []git.Hunk{{
+			Lines: []git.Line{
+				{Type: git.LineContext, Content: "para1 line a", NewNum: 1},
+				{Type: git.LineContext, Content: "para1 line b", NewNum: 2},
+				{Type: git.LineContext, Content: "", NewNum: 3},
+				{Type: git.LineContext, Content: "para2 line a", NewNum: 4},
+				{Type: git.LineContext, Content: "   ", NewNum: 5}, // whitespace-only counts as blank
+				{Type: git.LineContext, Content: "para3 line a", NewNum: 6},
+				{Type: git.LineContext, Content: "para3 line b", NewNum: 7},
+			},
+		}},
+	}
+	m.buildLines()
+	m.goToFirstNavigable()
+	// Sanity: blank lines detected at indices 2 and 4.
+	require.True(t, m.isBlankLine(2))
+	require.True(t, m.isBlankLine(4))
+	require.False(t, m.isBlankLine(0))
+	return m
+}
+
+func TestNextParagraph_FromTextLandsOnNextBlank(t *testing.T) {
+	m := makeParagraphModel(t)
+	m.cursor = 0
+	m.nextParagraph()
+	assert.Equal(t, 2, m.cursor)
+}
+
+func TestNextParagraph_FromBlankSkipsToFollowingBlank(t *testing.T) {
+	m := makeParagraphModel(t)
+	m.cursor = 2
+	m.nextParagraph()
+	assert.Equal(t, 4, m.cursor)
+}
+
+func TestNextParagraph_NoBlankBelowJumpsToLastLine(t *testing.T) {
+	m := makeParagraphModel(t)
+	m.cursor = 4 // last blank; only text remains below
+	m.nextParagraph()
+	assert.Equal(t, 6, m.cursor, "should jump to the last navigable line")
+}
+
+func TestPrevParagraph_FromTextLandsOnPrevBlank(t *testing.T) {
+	m := makeParagraphModel(t)
+	m.cursor = 5
+	m.prevParagraph()
+	assert.Equal(t, 4, m.cursor)
+}
+
+func TestPrevParagraph_FromBlankSkipsToPrecedingBlank(t *testing.T) {
+	m := makeParagraphModel(t)
+	m.cursor = 4
+	m.prevParagraph()
+	assert.Equal(t, 2, m.cursor)
+}
+
+func TestPrevParagraph_NoBlankAboveJumpsToTop(t *testing.T) {
+	m := makeParagraphModel(t)
+	m.cursor = 1 // inside the first paragraph, no blank above
+	m.prevParagraph()
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestParagraphJump_RoutedInAllModes(t *testing.T) {
+	// }/{ jump to blank lines regardless of mode (no separate hunk nav).
+	for _, fileReview := range []bool{true, false} {
+		dv := makeParagraphModel(t)
+		dv.fileReviewMode = fileReview
+		m := Model{diffView: dv, fileReviewMode: fileReview, focus: focusDiffView}
+
+		m = sendKey(m, "}")
+		assert.Equal(t, 2, m.diffView.cursor, "} jumps to next blank line (fileReview=%v)", fileReview)
+
+		m = sendKey(m, "{")
+		assert.Equal(t, 0, m.diffView.cursor, "{ jumps to prev boundary (fileReview=%v)", fileReview)
+	}
+}
+
+func TestHelp_ShowsBlankLineLabel(t *testing.T) {
+	found := false
+	for _, g := range BindingGroups() {
+		for _, b := range g.Bindings {
+			if b.Key == "}/{ (]/[)" {
+				found = true
+				assert.Equal(t, "Next/prev blank line", b.Desc)
+			}
+		}
+	}
+	assert.True(t, found, "}/{ binding should appear in help")
+}

--- a/internal/ui/search_test.go
+++ b/internal/ui/search_test.go
@@ -1,0 +1,357 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/justincampbell/revise/internal/git"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeSearchModel builds a file-review-style diff view whose source lines
+// contain the substring "alpha" on lines 0, 2, and 4 (case-insensitively):
+//
+//	0: alpha beta
+//	1: gamma delta
+//	2: Alpha again
+//	3: epsilon
+//	4: beta gamma alpha
+func makeSearchModel(t *testing.T) diffViewModel {
+	t.Helper()
+	m := newDiffViewModel()
+	m.height = 20
+	m.width = 80
+	m.fileReviewMode = true
+	m.file = &git.FileDiff{
+		Path: "doc.md",
+		Hunks: []git.Hunk{{
+			Lines: []git.Line{
+				{Type: git.LineContext, Content: "alpha beta", NewNum: 1},
+				{Type: git.LineContext, Content: "gamma delta", NewNum: 2},
+				{Type: git.LineContext, Content: "Alpha again", NewNum: 3},
+				{Type: git.LineContext, Content: "epsilon", NewNum: 4},
+				{Type: git.LineContext, Content: "beta gamma alpha", NewNum: 5},
+			},
+		}},
+	}
+	m.buildLines()
+	m.goToFirstNavigable()
+	require.Equal(t, 0, m.cursor)
+	return m
+}
+
+func TestMatchRanges_CaseInsensitive(t *testing.T) {
+	assert.Equal(t, [][2]int{{0, 5}}, matchRanges("Alpha again", "alpha"))
+	assert.Equal(t, [][2]int{{11, 16}}, matchRanges("beta gamma alpha", "alpha"))
+	assert.Nil(t, matchRanges("nothing here", "alpha"))
+	assert.Nil(t, matchRanges("anything", ""))
+}
+
+func TestMatchRanges_MultiplePerLine(t *testing.T) {
+	// "aXaXa" with query "a" → three matches.
+	assert.Equal(t, [][2]int{{0, 1}, {2, 3}, {4, 5}}, matchRanges("aXaXa", "a"))
+}
+
+func TestMatchColumnRanges_ASCII(t *testing.T) {
+	// For ASCII content, columns equal rune indices.
+	assert.Equal(t, [][2]int{{0, 5}}, matchColumnRanges("Alpha again", "alpha"))
+}
+
+func TestMatchColumnRanges_WideRunes(t *testing.T) {
+	// "日本 world": each CJK rune is 2 columns wide. "world" starts at rune
+	// index 3 but column 5 (2+2+1).
+	assert.Equal(t, [][2]int{{5, 10}}, matchColumnRanges("日本 world", "world"))
+}
+
+func makeLongLineSearchModel(t *testing.T, content string, width int) diffViewModel {
+	t.Helper()
+	m := newDiffViewModel()
+	m.height = 10
+	m.width = width
+	m.fileReviewMode = true
+	m.file = &git.FileDiff{
+		Path:  "doc.md",
+		Hunks: []git.Hunk{{Lines: []git.Line{{Type: git.LineContext, Content: content, NewNum: 1}}}},
+	}
+	m.buildLines()
+	m.goToFirstNavigable()
+	return m
+}
+
+func TestEnsureMatchVisible_ScrollsToOffscreenMatch(t *testing.T) {
+	content := strings.Repeat("x", 40) + "needle"
+	m := makeLongLineSearchModel(t, content, 23) // viewWidth = 20
+	m.searchOrigin = 0
+	m.setSearch("needle")
+
+	avail := m.width - 3
+	start := gutterWidth + 40 // match start column in the rendered line
+	end := gutterWidth + 46   // match end column
+	assert.Greater(t, m.hOffset, 0, "should scroll right to reveal the match")
+	assert.GreaterOrEqual(t, start, m.hOffset, "match start should be at/after the left edge")
+	assert.LessOrEqual(t, end, m.hOffset+avail, "match end should be within the viewport")
+}
+
+func TestEnsureMatchVisible_NoScrollWhenVisible(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchOrigin = 0
+	m.setSearch("alpha") // match near the start, line fits in width 80
+	assert.Equal(t, 0, m.hOffset)
+}
+
+func TestEnsureMatchVisible_NoScrollWhenWrapEnabled(t *testing.T) {
+	content := strings.Repeat("x", 40) + "needle"
+	m := makeLongLineSearchModel(t, content, 23)
+	m.wrapEnabled = true
+	m.searchOrigin = 0
+	m.setSearch("needle")
+	assert.Equal(t, 0, m.hOffset, "wrap on: no horizontal scroll")
+}
+
+func TestComputeSearchMatches(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchQuery = "alpha"
+	m.computeSearchMatches()
+	assert.Equal(t, []int{0, 2, 4}, m.searchMatches)
+}
+
+func TestComputeSearchMatches_EmptyQuery(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchQuery = ""
+	m.computeSearchMatches()
+	assert.Empty(t, m.searchMatches)
+	assert.Equal(t, -1, m.searchIdx)
+}
+
+func TestSetSearch_JumpsToFirstMatchFromOrigin(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchOrigin = 0
+	m.setSearch("alpha")
+	assert.Equal(t, []int{0, 2, 4}, m.searchMatches)
+	assert.Equal(t, 0, m.searchIdx)
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestSetSearch_JumpsToNextMatchAtOrAfterOrigin(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchOrigin = 1 // first match at or after line 1 is line 2
+	m.setSearch("alpha")
+	assert.Equal(t, 1, m.searchIdx)
+	assert.Equal(t, 2, m.cursor)
+}
+
+func TestSetSearch_WrapsWhenNoMatchAfterOrigin(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchOrigin = 4 // matches at 0,2,4; origin 4 lands on the last match
+	m.setSearch("alpha")
+	assert.Equal(t, 2, m.searchIdx)
+	assert.Equal(t, 4, m.cursor)
+
+	m2 := makeSearchModel(t)
+	m2.cursor = 3
+	m2.searchOrigin = 3 // no match at >=3 except 4 → lands on 4
+	m2.setSearch("epsilon")
+	require.Equal(t, []int{3}, m2.searchMatches)
+	assert.Equal(t, 0, m2.searchIdx)
+	assert.Equal(t, 3, m2.cursor)
+}
+
+func TestSetSearch_NoMatchKeepsCursor(t *testing.T) {
+	m := makeSearchModel(t)
+	m.cursor = 1
+	m.searchOrigin = 1
+	m.setSearch("zzzz")
+	assert.Empty(t, m.searchMatches)
+	assert.Equal(t, -1, m.searchIdx)
+	assert.Equal(t, 1, m.cursor, "cursor should not move when there are no matches")
+}
+
+func TestNextMatch_WrapsForward(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchOrigin = 0
+	m.setSearch("alpha") // idx 0, cursor 0
+	m.nextMatch()
+	assert.Equal(t, 1, m.searchIdx)
+	assert.Equal(t, 2, m.cursor)
+	m.nextMatch()
+	assert.Equal(t, 2, m.searchIdx)
+	assert.Equal(t, 4, m.cursor)
+	m.nextMatch() // wrap
+	assert.Equal(t, 0, m.searchIdx)
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestPrevMatch_WrapsBackward(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchOrigin = 0
+	m.setSearch("alpha") // idx 0, cursor 0
+	m.prevMatch()        // wrap to last
+	assert.Equal(t, 2, m.searchIdx)
+	assert.Equal(t, 4, m.cursor)
+	m.prevMatch()
+	assert.Equal(t, 1, m.searchIdx)
+	assert.Equal(t, 2, m.cursor)
+}
+
+func TestNextPrevMatch_NoMatchesNoop(t *testing.T) {
+	m := makeSearchModel(t)
+	m.cursor = 2
+	m.setSearch("zzzz")
+	m.nextMatch()
+	assert.Equal(t, 2, m.cursor)
+	m.prevMatch()
+	assert.Equal(t, 2, m.cursor)
+}
+
+func TestClearSearch(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchOrigin = 0
+	m.setSearch("alpha")
+	require.NotEmpty(t, m.searchMatches)
+	m.clearSearch()
+	assert.Equal(t, "", m.searchQuery)
+	assert.Empty(t, m.searchMatches)
+	assert.Equal(t, -1, m.searchIdx)
+}
+
+func TestSetFile_ClearsSearch(t *testing.T) {
+	m := makeSearchModel(t)
+	m.searchOrigin = 0
+	m.setSearch("alpha")
+	require.NotEmpty(t, m.searchMatches)
+	m.setFile(&git.FileDiff{
+		Path:  "other.md",
+		Hunks: []git.Hunk{{Lines: []git.Line{{Type: git.LineContext, Content: "x", NewNum: 1}}}},
+	})
+	assert.Equal(t, "", m.searchQuery)
+	assert.Empty(t, m.searchMatches)
+}
+
+// --- Model-level routing ---
+
+func makeSearchableFileReview() Model {
+	return makeFileReviewModel([]git.Line{
+		{Type: git.LineContext, Content: "alpha beta", OldNum: 1, NewNum: 1},
+		{Type: git.LineContext, Content: "gamma delta", OldNum: 2, NewNum: 2},
+		{Type: git.LineContext, Content: "Alpha again", OldNum: 3, NewNum: 3},
+		{Type: git.LineContext, Content: "epsilon", OldNum: 4, NewNum: 4},
+		{Type: git.LineContext, Content: "beta gamma alpha", OldNum: 5, NewNum: 5},
+	})
+}
+
+func TestSearch_SlashOpensSearch(t *testing.T) {
+	m := makeSearchableFileReview()
+	m = sendKey(m, "/")
+	assert.True(t, m.searchActive)
+	assert.Equal(t, focusDiffView, m.focus)
+}
+
+func TestSearch_IncrementalTypingHighlightsAndJumps(t *testing.T) {
+	m := makeSearchableFileReview()
+	m = sendKey(m, "/")
+	m = sendKey(m, "alpha")
+	assert.Equal(t, "alpha", m.diffView.searchQuery)
+	assert.Equal(t, []int{0, 2, 4}, m.diffView.searchMatches)
+	assert.Equal(t, 0, m.diffView.cursor)
+}
+
+func TestSearch_EnterCommitsAndRetainsQuery(t *testing.T) {
+	m := makeSearchableFileReview()
+	m = sendKey(m, "/")
+	m = sendKey(m, "alpha")
+	m = sendSpecialKey(m, tea.KeyEnter)
+	assert.False(t, m.searchActive)
+	assert.Equal(t, "alpha", m.diffView.searchQuery)
+	assert.Equal(t, []int{0, 2, 4}, m.diffView.searchMatches)
+}
+
+func TestSearch_EscInBoxClears(t *testing.T) {
+	m := makeSearchableFileReview()
+	m = sendKey(m, "/")
+	m = sendKey(m, "alpha")
+	m = sendSpecialKey(m, tea.KeyEsc)
+	assert.False(t, m.searchActive)
+	assert.Equal(t, "", m.diffView.searchQuery)
+	assert.Empty(t, m.diffView.searchMatches)
+}
+
+func TestSearch_EscAfterCommitClears(t *testing.T) {
+	m := makeSearchableFileReview()
+	m = sendKey(m, "/")
+	m = sendKey(m, "alpha")
+	m = sendSpecialKey(m, tea.KeyEnter)
+	require.Equal(t, "alpha", m.diffView.searchQuery)
+	m = sendSpecialKey(m, tea.KeyEsc)
+	assert.Equal(t, "", m.diffView.searchQuery)
+}
+
+func TestSearch_BackspaceOnEmptyExits(t *testing.T) {
+	m := makeSearchableFileReview()
+	m = sendKey(m, "/")
+	require.True(t, m.searchActive)
+	m = sendSpecialKey(m, tea.KeyBackspace)
+	assert.False(t, m.searchActive, "backspace on empty search box exits search mode")
+	assert.Equal(t, "", m.diffView.searchQuery)
+}
+
+func TestSearch_BackspaceDeletesWhenNonEmpty(t *testing.T) {
+	m := makeSearchableFileReview()
+	m = sendKey(m, "/")
+	m = sendKey(m, "al")
+	require.Equal(t, "al", m.diffView.searchQuery)
+	m = sendSpecialKey(m, tea.KeyBackspace)
+	assert.True(t, m.searchActive, "still searching after deleting one character")
+	assert.Equal(t, "a", m.diffView.searchQuery)
+}
+
+func TestSearch_NNavigatesMatchesWhenActive(t *testing.T) {
+	m := makeSearchableFileReview()
+	m = sendKey(m, "/")
+	m = sendKey(m, "alpha")
+	m = sendSpecialKey(m, tea.KeyEnter)
+	require.Equal(t, 0, m.diffView.cursor)
+	m = sendKey(m, "n")
+	assert.Equal(t, 2, m.diffView.cursor)
+	m = sendKey(m, "n")
+	assert.Equal(t, 4, m.diffView.cursor)
+	m = sendKey(m, "N")
+	assert.Equal(t, 2, m.diffView.cursor)
+}
+
+func TestSearch_NNavigatesFilesWhenNoSearch(t *testing.T) {
+	m := makeModel("a.go", "b.go")
+	require.Equal(t, 0, m.fileList.cursor)
+	m = sendKey(m, "n")
+	assert.Equal(t, 1, m.fileList.cursor, "n moves to the next file when not searching")
+	m = sendKey(m, "N")
+	assert.Equal(t, 0, m.fileList.cursor)
+}
+
+func TestSearch_HelpShowsSearchGroup(t *testing.T) {
+	found := false
+	for _, g := range BindingGroups() {
+		if g.Name == "Search" {
+			found = true
+			keys := ""
+			for _, b := range g.Bindings {
+				keys += b.Key + " "
+			}
+			assert.Contains(t, keys, "/")
+			assert.Contains(t, keys, "n/N")
+		}
+	}
+	assert.True(t, found, "help should include a Search binding group")
+}
+
+func TestSearch_GroupVisibleInFileReviewHelp(t *testing.T) {
+	// Search bindings are not git-only, so they survive the file-review filter.
+	found := false
+	for _, g := range FileReviewBindingGroups() {
+		if g.Name == "Search" {
+			found = true
+		}
+	}
+	assert.True(t, found, "Search group should appear in file review help")
+}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -93,6 +93,9 @@ var (
 	// Inline comment input box
 	commentInputStyle lipgloss.Style
 
+	// Search match highlight (substring within a matched line)
+	searchMatchStyle lipgloss.Style
+
 	// Mode slider styles
 	modeActiveStyle   lipgloss.Style
 	modeInactiveStyle lipgloss.Style
@@ -193,6 +196,9 @@ func applyTheme(p themeColors) {
 		BorderForeground(p.yellow).
 		Padding(0, 1)
 
+	// Black-on-yellow keeps matches legible over any diff-line background.
+	searchMatchStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#1a1a1a")).Background(p.yellow).Bold(true)
+
 	modeActiveStyle = lipgloss.NewStyle().Foreground(p.cyan).Bold(true)
 	modeInactiveStyle = lipgloss.NewStyle().Foreground(p.dim)
 	modeDisabledStyle = lipgloss.NewStyle().Foreground(p.dim).Faint(true).Strikethrough(true)
@@ -257,6 +263,7 @@ func applyNoColor() {
 	markPrefixStyle = lipgloss.NewStyle().Bold(true)
 	commentPrefixStyle = lipgloss.NewStyle().Bold(true)
 	commentInputStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
+	searchMatchStyle = lipgloss.NewStyle().Reverse(true).Bold(true)
 	modeActiveStyle = lipgloss.NewStyle().Bold(true)
 	modeInactiveStyle = lipgloss.NewStyle()
 	modeDisabledStyle = lipgloss.NewStyle().Faint(true).Strikethrough(true)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -81,12 +81,12 @@ var (
 	commentDisplayStyle lipgloss.Style
 
 	// Marked line styles
-	markAddedStyle    lipgloss.Style
-	markRemovedStyle  lipgloss.Style
-	markContextStyle  lipgloss.Style
-	markGutterAdded   lipgloss.Style
-	markGutterRemoved lipgloss.Style
-	markGutterContext lipgloss.Style
+	markAddedStyle     lipgloss.Style
+	markRemovedStyle   lipgloss.Style
+	markContextStyle   lipgloss.Style
+	markGutterAdded    lipgloss.Style
+	markGutterRemoved  lipgloss.Style
+	markGutterContext  lipgloss.Style
 	markPrefixStyle    lipgloss.Style // bookmark stripe in the leading 1-char prefix column
 	commentPrefixStyle lipgloss.Style // bookmark stripe for commented lines
 

--- a/internal/ui/syntax.go
+++ b/internal/ui/syntax.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"sync"
 
+	"charm.land/lipgloss/v2"
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/alecthomas/chroma/v2/styles"
-	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/justincampbell/revise/internal/git"
 )

--- a/internal/ui/syntax_test.go
+++ b/internal/ui/syntax_test.go
@@ -219,9 +219,9 @@ func TestRenderDiffLine_HighlightedVsFallback(t *testing.T) {
 	line := git.Line{Type: git.LineAdded, Content: "package main", NewNum: 1}
 
 	// With a known Go file — should highlight
-	withHighlight := renderDiffLine(line, false, 80, "main.go", p, 0)
+	withHighlight := renderDiffLine(line, false, 80, "main.go", p, 0, "")
 	// With unknown extension — plain fallback
-	withoutHighlight := renderDiffLine(line, false, 80, "file.xyzunknown", p, 0)
+	withoutHighlight := renderDiffLine(line, false, 80, "file.xyzunknown", p, 0, "")
 
 	assert.NotEmpty(t, withHighlight)
 	assert.NotEmpty(t, withoutHighlight)
@@ -296,8 +296,8 @@ func TestRenderDiffLine_MarkedSkipsHighlight(t *testing.T) {
 	p := paletteFor(ThemeCharmtoneDark, true)
 	line := git.Line{Type: git.LineAdded, Content: "package main", NewNum: 1}
 
-	marked := renderDiffLine(line, true, 80, "main.go", p, 0)
-	unmarked := renderDiffLine(line, false, 80, "main.go", p, 0)
+	marked := renderDiffLine(line, true, 80, "main.go", p, 0, "")
+	unmarked := renderDiffLine(line, false, 80, "main.go", p, 0, "")
 
 	// Marked lines use mark styles, not syntax highlight styles — they differ
 	assert.NotEqual(t, marked, unmarked)

--- a/internal/ui/syntax_test.go
+++ b/internal/ui/syntax_test.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	chromachroma "github.com/alecthomas/chroma/v2"
 	chromalexers "github.com/alecthomas/chroma/v2/lexers"
 	chromastyles "github.com/alecthomas/chroma/v2/styles"
-	"charm.land/lipgloss/v2"
 	"github.com/justincampbell/revise/internal/git"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -11,16 +11,16 @@ import (
 type Theme string
 
 const (
-	ThemeAuto                    Theme = "auto"
-	ThemeAutoDaltonized          Theme = "auto-daltonized"
-	ThemeCharmtoneDark           Theme = "charmtone-dark"
-	ThemeCharmtoneDarkDaltonized Theme = "charmtone-dark-daltonized"
-	ThemeCharmtoneLight          Theme = "charmtone-light"
+	ThemeAuto                     Theme = "auto"
+	ThemeAutoDaltonized           Theme = "auto-daltonized"
+	ThemeCharmtoneDark            Theme = "charmtone-dark"
+	ThemeCharmtoneDarkDaltonized  Theme = "charmtone-dark-daltonized"
+	ThemeCharmtoneLight           Theme = "charmtone-light"
 	ThemeCharmtoneLightDaltonized Theme = "charmtone-light-daltonized"
-	ThemeGithubDark              Theme = "github-dark"
-	ThemeGithubDarkDaltonized    Theme = "github-dark-daltonized"
-	ThemeGithubLight             Theme = "github-light"
-	ThemeGithubLightDaltonized   Theme = "github-light-daltonized"
+	ThemeGithubDark               Theme = "github-dark"
+	ThemeGithubDarkDaltonized     Theme = "github-dark-daltonized"
+	ThemeGithubLight              Theme = "github-light"
+	ThemeGithubLightDaltonized    Theme = "github-light-daltonized"
 )
 
 // ValidThemes lists all accepted --theme values.
@@ -108,13 +108,13 @@ func charmtoneDarkChromaEntries(daltonized bool) chroma.StyleEntries {
 		chroma.GenericSubheading:   "#858392", // Squid
 	}
 	if daltonized {
-		entries[chroma.NameFunction] = "#4FBEFE"   // Sardine (blue)
+		entries[chroma.NameFunction] = "#4FBEFE"    // Sardine (blue)
 		entries[chroma.Operator] = "#E8FE96"        // Zest (yellow)
 		entries[chroma.GenericInserted] = "#4FBEFE" // Sardine (blue)
 		entries[chroma.GenericDeleted] = "#FF985A"  // Tang (orange)
 		entries[chroma.LiteralNumber] = "#4FBEFE"   // Sardine (blue)
 	} else {
-		entries[chroma.NameFunction] = "#12C78F"   // Guac (green)
+		entries[chroma.NameFunction] = "#12C78F"    // Guac (green)
 		entries[chroma.Operator] = "#FF7F90"        // Salmon (pink)
 		entries[chroma.GenericInserted] = "#12C78F" // Guac
 		entries[chroma.GenericDeleted] = "#FF577D"  // Coral (red)
@@ -266,7 +266,7 @@ func autoDaltonizedPalette() themeColors {
 	p.addedFg = lipgloss.Blue
 	p.addedBg = lipgloss.Color("#1a1f2e")
 	p.gutterAddedFg = lipgloss.Color("27") // ANSI 256: muted blue
-	p.markBg = lipgloss.Color("#5a2d6e") // purple — distinct from blue addedBg
+	p.markBg = lipgloss.Color("#5a2d6e")   // purple — distinct from blue addedBg
 	p.markFg = lipgloss.Color("#c084fc")
 	return p
 }
@@ -292,10 +292,10 @@ func charmtoneDarkPalette() themeColors {
 
 func charmtoneDarkDaltonizedPalette() themeColors {
 	p := charmtoneDarkPalette()
-	p.addedFg = lipgloss.Color("#4FBEFE") // Sardine (blue)
-	p.addedBg = lipgloss.Color("#0F2A4A") // deep navy
+	p.addedFg = lipgloss.Color("#4FBEFE")  // Sardine (blue)
+	p.addedBg = lipgloss.Color("#0F2A4A")  // deep navy
 	p.dimGreen = lipgloss.Color("#007AB8") // Damson
-	p.markBg = lipgloss.Color("#5a2d6e") // purple — distinct from blue addedBg
+	p.markBg = lipgloss.Color("#5a2d6e")   // purple — distinct from blue addedBg
 	p.markFg = lipgloss.Color("#c084fc")
 	return p
 }

--- a/internal/ui/wrap_test.go
+++ b/internal/ui/wrap_test.go
@@ -1,0 +1,156 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/justincampbell/revise/internal/git"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wrapModel builds a model where every navigable line is `width` columns wide,
+// so wrapped row counts are predictable in tests. Gutter width is 6, so the
+// content after the gutter is width-6 columns.
+func wrapModel(lineCount, height, paneWidth, lineWidth int) diffViewModel {
+	m := makeDiffViewModel(lineCount, height)
+	m.width = paneWidth
+	m.wrapEnabled = true
+	for i := range m.lines {
+		m.lines[i] = strings.Repeat("A", lineWidth)
+	}
+	return m
+}
+
+func TestDisplayRows_WrapOff_AlwaysSingleRow(t *testing.T) {
+	m := makeDiffViewModel(1, 10)
+	m.width = 20 // viewWidth = 17
+	m.lines[0] = strings.Repeat("A", 40)
+	rows := m.displayRows(0, m.viewWidth(), 0)
+	assert.Len(t, rows, 1, "wrap off should never split a line")
+}
+
+func TestDisplayRows_WrapOn_SplitsAndIndents(t *testing.T) {
+	m := makeDiffViewModel(1, 10)
+	m.width = 26 // viewWidth = 23
+	m.wrapEnabled = true
+	m.lines[0] = strings.Repeat("A", 40)
+	avail := m.viewWidth() // 23, gutter 6 → contentAvail 17, content 34 → ceil(34/17)=2
+	rows := m.displayRows(0, avail, 0)
+
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		assert.LessOrEqual(t, ansi.StringWidth(r), avail, "no wrapped row should exceed the available width")
+	}
+	// Continuation row is indented past the gutter so content aligns.
+	assert.True(t, strings.HasPrefix(rows[1], strings.Repeat(" ", gutterWidth)),
+		"continuation row should be indented by the gutter width")
+}
+
+func TestDisplayRows_WrapOn_ShortLineStaysSingle(t *testing.T) {
+	m := makeDiffViewModel(1, 10)
+	m.width = 40
+	m.wrapEnabled = true
+	m.lines[0] = "short"
+	rows := m.displayRows(0, m.viewWidth(), 0)
+	assert.Len(t, rows, 1)
+}
+
+func TestLineRows_CountsWrappedRows(t *testing.T) {
+	// pane 26 → viewWidth 23, gutter 6 → contentAvail 17.
+	m := wrapModel(1, 10, 26, 6+17*2) // content exactly 2 full rows
+	assert.Equal(t, 2, m.lineRows(0, m.viewWidth()))
+}
+
+func TestToggleWrap_FlipsAndResetsHOffset(t *testing.T) {
+	m := makeDiffViewModel(3, 10)
+	m.hOffset = 12
+	require.False(t, m.wrapEnabled)
+
+	m.toggleWrap()
+	assert.True(t, m.wrapEnabled)
+	assert.Equal(t, 0, m.hOffset, "enabling wrap resets horizontal scroll")
+
+	m.toggleWrap()
+	assert.False(t, m.wrapEnabled)
+}
+
+func TestEnsureCursorVisible_WrapScrollsSoCursorFits(t *testing.T) {
+	// viewH 4, each line 2 rows → only 2 logical lines fit at once.
+	m := wrapModel(10, 4, 26, 6+17+1) // 6+18 → contentAvail 17 → ceil(18/17)=2 rows
+	require.Equal(t, 2, m.lineRows(0, m.viewWidth()))
+
+	m.cursor = 5
+	m.ensureCursorVisible()
+	assert.Equal(t, 4, m.offset, "offset should advance so the 2-row cursor line is visible")
+}
+
+func TestLineAtRow_WrapMapsRowsToLogicalLines(t *testing.T) {
+	m := wrapModel(5, 10, 26, 6+17+1) // 2 rows per line
+	avail := m.viewWidth()
+	assert.Equal(t, 0, m.lineAtRow(0, 0, avail))
+	assert.Equal(t, 0, m.lineAtRow(0, 1, avail))
+	assert.Equal(t, 1, m.lineAtRow(0, 2, avail))
+	assert.Equal(t, 2, m.lineAtRow(0, 4, avail))
+}
+
+func TestClickToAbsIdx_WrapNoInputBox(t *testing.T) {
+	m := wrapModel(5, 10, 26, 6+17+1) // 2 rows per line
+	m.offset = 0
+	// Display row 2 is the first row of logical line 1.
+	assert.Equal(t, 1, m.clickToAbsIdx(2))
+}
+
+func TestBottomOffset_Wrap(t *testing.T) {
+	m := wrapModel(10, 4, 26, 6+17+1) // 2 rows per line, viewH 4
+	assert.Equal(t, 8, m.bottomOffset())
+}
+
+func TestLastVisibleLine_Wrap(t *testing.T) {
+	m := wrapModel(10, 4, 26, 6+17+1) // 2 rows per line, viewH 4
+	m.offset = 2
+	assert.Equal(t, 3, m.lastVisibleLine())
+}
+
+func TestRender_WrapKeepsRowsWithinWidthAndShowsIndicator(t *testing.T) {
+	m := newDiffViewModel()
+	m.width = 30
+	m.height = 10
+	m.file = &git.FileDiff{
+		Path: "doc.md",
+		Hunks: []git.Hunk{{
+			Header: "@@ -1,1 +1,1 @@",
+			Lines:  []git.Line{{Type: git.LineContext, Content: strings.Repeat("word ", 30), NewNum: 1}},
+		}},
+	}
+	m.buildLines()
+	m.goToFirstNavigable()
+	m.wrapEnabled = true
+
+	out := m.render(true, 3, false)
+	assert.Contains(t, ansi.Strip(out), "Wrap", "footer should show the wrap indicator")
+	for _, line := range strings.Split(out, "\n") {
+		assert.LessOrEqual(t, ansi.StringWidth(line), m.width,
+			"every rendered row (incl. borders) must fit the pane width")
+	}
+}
+
+func TestRender_WrapFileReviewShowsIndicator(t *testing.T) {
+	m := newDiffViewModel()
+	m.fileReviewMode = true
+	m.width = 30
+	m.height = 8
+	m.file = &git.FileDiff{
+		Path: "doc.md",
+		Hunks: []git.Hunk{{
+			Lines: []git.Line{{Type: git.LineContext, Content: strings.Repeat("word ", 30), NewNum: 1}},
+		}},
+	}
+	m.buildLines()
+	m.goToFirstNavigable()
+	m.wrapEnabled = true
+
+	out := ansi.Strip(m.render(true, 3, false, "doc.md"))
+	assert.Contains(t, out, "Wrap")
+}


### PR DESCRIPTION
Three features aimed at reviewing prose-heavy planning/architecture docs in `revise`, bundled on one branch.

## Changes

- **#163 — Soft line wrap (`W`)**: wraps long lines onto multiple display rows at the viewport width instead of clipping. Continuation rows are indented past the gutter; a `Wrap` indicator shows on the bottom border. Cursor/offset stay logical-line indices so navigation is unaffected.
- **#122 — `}`/`{` jump blank lines in all modes**: paragraph-style jumping (Vim `}`/`{`) now works consistently in git diff and file review. In a diff the nearest blank line usually sits at the next change, so this doubles as change-to-change nav. Dedicated hunk-to-hunk nav removed.
- **#72 — Incremental search (`/`)**: search the current file's diff. Matched text highlights as you type (surrounding syntax colors preserved via a column-wise ANSI overlay), the cursor jumps to the nearest match, and `n`/`N` step between matches with wraparound. Off-screen matches scroll into view horizontally. `Enter` commits (status bar shows `current/total` + nav hint), `Esc` clears, backspace on an empty box exits. Case-insensitive, scoped to the current file; `n`/`N` keep their next/prev-file meaning when no search is active.

Plus a small `goimports` formatting commit for `internal/ui`.

## Testing

- TDD for all logic (search matching/navigation, column conversion, horizontal scroll, paragraph jumps, wrap row math); UI rendering verified manually via `make install`.
- `make test` and `make lint` green (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incremental search within the current file using `/`, with case-insensitive matching and `n`/`N` navigation between matches.
  * Soft line wrapping toggle (`W`) for improved readability in diff view.
  * Launch external editor (`E`) to open the current file at the cursor line.

* **Changed**
  * Navigation keys `}`/`{` and `]`/`[` now jump to blank lines instead of hunks.

* **Documentation**
  * Updated keybinding reference with new search, wrap, and editor launch features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->