### PR TITLE
Highlight Markdown headings and fenced code blocks (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Markdown files now render headings in bold and syntax-highlight fenced code blocks using their declared language (e.g. ` ```go `), in addition to the inline `**bold**`/`` `code` `` formatting that already worked. Code inside a fence is highlighted with that language's lexer; bare (language-less) fences stay plain. Works in both git diff and file review mode (#194)
+
 ## [0.5.0] - 2026-06-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,9 @@ internal/
     diffview.go                # right panel: diff renderer + scroll
     keys.go                    # keyboard binding definitions (single source of truth)
     styles.go                  # all Lipgloss styles, NO_COLOR support
+    theme.go                   # color palettes + chroma style entries per theme
+    syntax.go                  # chroma syntax highlighting, indent guides, Markdown fences
+    syntax_test.go             # highlight, fence detection, indent guide tests
     comment.go                 # comment types, serialization for persistence
     comment_test.go            # comment encode/decode tests
     help.go                    # help overlay
@@ -177,6 +180,14 @@ Four modes: ModeBranch (broadest), ModeStaged, ModeStagedOnly, ModeUnstaged (nar
 - Focused panel gets cyan border; unfocused gets dim border
 - Help overlay uses yellow border to distinguish from panels
 - Lipgloss `Width(n)`/`Height(n)` include padding but exclude borders — when setting explicit dimensions, add padding to the content size
+
+### Syntax Highlighting
+
+`internal/ui/syntax.go` highlights each line via chroma (`highlightLine`), keyed by `lexerFor(filePath)`. Highlighting is **line-by-line** so it composes with per-line diff backgrounds and the per-line cache — the trade-off is that multi-line lexer state (block comments, raw strings) isn't tracked, which is acceptable and consistent for all languages. Per-theme token colors live in `theme.go` (`chromaStyleEntries`); the custom `chromaFormatter` bakes the diff background into every token so ANSI resets don't clear it mid-line.
+
+Markdown gets two extras (#194):
+- **Headings**: chroma only emits `GenericHeading`/`GenericSubheading` when the line ends in a newline, so `highlightLine` appends `\n` before tokenising (the formatter trims and skips the resulting empty token). The formatter force-bolds heading tokens so they stand out even under named chroma styles (e.g. "github") that don't bold them; custom themes also give headings a color in `theme.go`.
+- **Fenced code blocks**: `buildLines` runs a per-hunk fence state machine (`codeFenceLang` detects ` ``` `/`~~~` open/close + info-string language). Lines inside a fence are highlighted with the declared language via the `langOverride` param threaded through `renderDiffLine` → `highlightLine` (`lexerByName`, case-insensitive, alias-aware). `langOverride` is part of the highlight cache key. Fence state resets per hunk since a diff's hidden gaps make cross-hunk tracking unreliable. Only active for Markdown files (`isMarkdownFile`).
 
 ### File Review Mode
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ revise --output comments.md <file>
 
 Opens the file in a read-only review mode — all lines shown as context, git-specific keys disabled. Add comments, then quit — comments are printed to stdout on exit. Use `--output <file>` to write comments to a file instead.
 
+Source is syntax-highlighted by file type. Markdown gets bold headings, inline `**bold**`/`` `code` ``, and fenced code blocks highlighted by their declared language (e.g. ` ```go `).
+
 Comments are also output on exit in normal git diff mode.
 
 ### Subcommands

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -317,10 +317,16 @@ func (m *diffViewModel) buildLines() {
 
 	p := paletteFor(activeTheme, activeIsDark)
 	indentSize := detectIndentSize(m.file.Hunks)
+	isMarkdown := isMarkdownFile(m.file.Path)
 	for _, hunk := range m.file.Hunks {
 		if header := renderHunkHeader(hunk); header != "" {
 			add(header, nil)
 		}
+		// Track fenced-code-block state within the hunk so code is highlighted
+		// with its declared language (e.g. ```go). Reset per hunk: a diff's
+		// hidden gaps make cross-hunk fence state unreliable.
+		inCodeBlock := false
+		codeLang := ""
 		for _, line := range hunk.Lines {
 			ref := &lineRef{
 				newNum:   line.NewNum,
@@ -335,7 +341,21 @@ func (m *diffViewModel) buildLines() {
 			if fillWidth < 1 {
 				fillWidth = 1
 			}
-			add(renderDiffLine(line, isMarked, fillWidth, m.file.Path, p, indentSize, m.searchQuery), ref)
+			// Resolve the language for lines inside a fenced code block; the
+			// fence delimiters themselves render as plain Markdown.
+			langOverride := ""
+			if isMarkdown {
+				if fence, lang := codeFenceLang(line.Content); fence {
+					if inCodeBlock {
+						inCodeBlock, codeLang = false, ""
+					} else {
+						inCodeBlock, codeLang = true, lang
+					}
+				} else if inCodeBlock {
+					langOverride = codeLang
+				}
+			}
+			add(renderDiffLine(line, isMarked, fillWidth, m.file.Path, p, indentSize, m.searchQuery, langOverride), ref)
 
 			// If this code line has a saved comment, add a display line below it.
 			key := ref.commentKey(m.file.Path)
@@ -869,7 +889,7 @@ func (m diffViewModel) clickToAbsIdx(clickY int) int {
 	return m.lineAtRow(nextIdx, clickY-codeAbove-inputBoxHeight, avail)
 }
 
-func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p themeColors, indentSize int, query string) string {
+func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p themeColors, indentSize int, query, langOverride string) string {
 	gutter := git.FormatGutter(l)
 	if marked {
 		content := l.Content
@@ -898,21 +918,21 @@ func renderDiffLine(l git.Line, marked bool, fillWidth int, filePath string, p t
 	switch l.Type {
 	case git.LineAdded:
 		gutterStyle = addedGutterStyle
-		if highlighted, ok := highlightLine(l.Content, filePath, p.addedBg, indentSize); ok {
+		if highlighted, ok := highlightLine(l.Content, filePath, p.addedBg, indentSize, langOverride); ok {
 			content = highlighted
 		} else {
 			content = addedStyle.Render(addIndentGuides(l.Content, indentSize, p.addedBg))
 		}
 	case git.LineRemoved:
 		gutterStyle = removedGutterStyle
-		if highlighted, ok := highlightLine(l.Content, filePath, p.removedBg, indentSize); ok {
+		if highlighted, ok := highlightLine(l.Content, filePath, p.removedBg, indentSize, langOverride); ok {
 			content = highlighted
 		} else {
 			content = removedStyle.Render(addIndentGuides(l.Content, indentSize, p.removedBg))
 		}
 	case git.LineContext:
 		gutterStyle = contextGutterStyle
-		if highlighted, ok := highlightLine(l.Content, filePath, nil, indentSize); ok {
+		if highlighted, ok := highlightLine(l.Content, filePath, nil, indentSize, langOverride); ok {
 			content = highlighted
 		} else {
 			content = contextStyle.Render(addIndentGuides(l.Content, indentSize, nil))

--- a/internal/ui/syntax.go
+++ b/internal/ui/syntax.go
@@ -40,6 +40,14 @@ var (
 	fileLexerCacheMu sync.Mutex
 )
 
+// nameLexerCache caches the resolved lexer per language name (used for fenced
+// Markdown code blocks, where the language comes from the fence info string
+// rather than the file path).
+var (
+	nameLexerCache   = map[string]chroma.Lexer{}
+	nameLexerCacheMu sync.Mutex
+)
+
 // clearHighlightCache discards all cached highlighted lines. Called by SetTheme
 // so stale theme-keyed entries don't persist after a theme change.
 func clearHighlightCache() {
@@ -64,16 +72,48 @@ func lexerFor(filePath string) chroma.Lexer {
 	return l
 }
 
+// lexerByName returns the chroma lexer for a language name or alias (e.g. "go",
+// "js"), or nil if unknown. Matching is case-insensitive. Results are cached.
+func lexerByName(name string) chroma.Lexer {
+	nameLexerCacheMu.Lock()
+	defer nameLexerCacheMu.Unlock()
+	if l, ok := nameLexerCache[name]; ok {
+		return l
+	}
+	l := lexers.Get(name)
+	if l != nil {
+		l = chroma.Coalesce(l)
+	}
+	nameLexerCache[name] = l
+	return l
+}
+
+// isMarkdownFile reports whether the file at filePath is highlighted by the
+// Markdown lexer. Used to enable fenced-code-block detection.
+func isMarkdownFile(filePath string) bool {
+	l := lexerFor(filePath)
+	return l != nil && l.Config().Name == "markdown"
+}
+
 // highlightLine applies chroma syntax highlighting to a single line of content,
 // with the given background color baked into every token via a custom formatter.
 // Returns the ANSI-colored string and true if highlighting was applied, or the
-// original content and false if NO_COLOR is set or no lexer matches the file.
-func highlightLine(content, filePath string, bg color.Color, indentSize int) (string, bool) {
+// original content and false if NO_COLOR is set or no lexer matches.
+//
+// When langOverride is non-empty, that language's lexer is used instead of the
+// one inferred from filePath. This lets fenced Markdown code blocks be
+// highlighted with their declared language (e.g. ```go).
+func highlightLine(content, filePath string, bg color.Color, indentSize int, langOverride string) (string, bool) {
 	if noColor {
 		return content, false
 	}
 
-	lexer := lexerFor(filePath)
+	var lexer chroma.Lexer
+	if langOverride != "" {
+		lexer = lexerByName(langOverride)
+	} else {
+		lexer = lexerFor(filePath)
+	}
 	if lexer == nil {
 		return content, false
 	}
@@ -86,7 +126,7 @@ func highlightLine(content, filePath string, bg color.Color, indentSize int) (st
 		r, g, b, a := bg.RGBA()
 		bgKey = fmt.Sprintf("%d,%d,%d,%d", r, g, b, a)
 	}
-	cacheKey := string(theme) + "\x00" + filePath + "\x00" + bgKey + "\x00" + content
+	cacheKey := string(theme) + "\x00" + filePath + "\x00" + langOverride + "\x00" + bgKey + "\x00" + content
 	if cached, ok := highlightCache[cacheKey]; ok {
 		highlightCacheMu.Unlock()
 		return cached, true
@@ -113,7 +153,10 @@ func highlightLine(content, filePath string, bg color.Color, indentSize int) (st
 	// then prepend the rendered indent guides.
 	guides, stripped := splitLeadingWhitespace(content, indentSize, bg)
 
-	it, err := lexer.Tokenise(nil, stripped)
+	// Append a newline so line-anchored lexer rules fire — the Markdown lexer
+	// only recognises a heading (and similar constructs) when the line ends in a
+	// newline. The formatter trims and skips the resulting empty token.
+	it, err := lexer.Tokenise(nil, stripped+"\n")
 	if err != nil {
 		return content, false
 	}
@@ -154,9 +197,19 @@ type chromaFormatter struct {
 func (c chromaFormatter) Format(w io.Writer, style *chroma.Style, it chroma.Iterator) error {
 	for token := it(); token != chroma.EOF; token = it() {
 		value := escapeControlChars(strings.TrimRight(token.Value, "\n"))
+		// Skip empty tokens (e.g. the appended trailing newline) so styling an
+		// empty string doesn't emit stray escape sequences.
+		if value == "" {
+			continue
+		}
+
+		// Markdown headings (Generic.Heading / Generic.Subheading) should always
+		// stand out as headings. Not every chroma style bolds them (the "github"
+		// style, used for light themes, leaves them unstyled), so force bold here.
+		isHeading := token.Type == chroma.GenericHeading || token.Type == chroma.GenericSubheading
 
 		entry := style.Get(token.Type)
-		if entry.IsZero() {
+		if entry.IsZero() && !isHeading {
 			_, _ = fmt.Fprint(w, value)
 			continue
 		}
@@ -167,7 +220,7 @@ func (c chromaFormatter) Format(w io.Writer, style *chroma.Style, it chroma.Iter
 		if c.bg != nil {
 			s = s.Background(c.bg)
 		}
-		if entry.Bold == chroma.Yes {
+		if entry.Bold == chroma.Yes || isHeading {
 			s = s.Bold(true)
 		}
 		// Skip italic for overridden comments — some terminals render
@@ -291,6 +344,41 @@ func addIndentGuides(content string, indentSize int, bg color.Color) string {
 	}
 	guides, rest := splitLeadingWhitespace(content, indentSize, bg)
 	return guides + rest
+}
+
+// codeFenceLang reports whether a line is a Markdown fenced-code delimiter
+// (``` or ~~~, optionally indented) and returns the info-string language.
+// For an opening fence the language is the first token of the info string,
+// lowercased (e.g. "go" for "```go"); it is "" for a bare fence (which may be
+// either an opening fence with no language or a closing fence).
+func codeFenceLang(content string) (isFence bool, lang string) {
+	t := strings.TrimLeft(content, " ")
+	var fenceChar byte
+	switch {
+	case strings.HasPrefix(t, "```"):
+		fenceChar = '`'
+	case strings.HasPrefix(t, "~~~"):
+		fenceChar = '~'
+	default:
+		return false, ""
+	}
+
+	// Skip the run of fence characters.
+	i := 0
+	for i < len(t) && t[i] == fenceChar {
+		i++
+	}
+	info := strings.TrimSpace(t[i:])
+
+	// A backtick info string may not contain backticks (CommonMark): this avoids
+	// treating inline code like `x = ``y`` ` as a fence.
+	if fenceChar == '`' && strings.Contains(info, "`") {
+		return false, ""
+	}
+	if info == "" {
+		return true, ""
+	}
+	return true, strings.ToLower(strings.Fields(info)[0])
 }
 
 // escapeControlChars replaces control characters with Unicode Control Picture

--- a/internal/ui/syntax.go
+++ b/internal/ui/syntax.go
@@ -228,7 +228,9 @@ func (c chromaFormatter) Format(w io.Writer, style *chroma.Style, it chroma.Iter
 		if entry.Italic == chroma.Yes && !isComment {
 			s = s.Italic(true)
 		}
-		if entry.Underline == chroma.Yes {
+		// Headings are distinguished by bold alone; skip underline (the "native"
+		// chroma style, used by the auto theme, underlines heading tokens).
+		if entry.Underline == chroma.Yes && !isHeading {
 			s = s.Underline(true)
 		}
 		if isComment {

--- a/internal/ui/syntax_test.go
+++ b/internal/ui/syntax_test.go
@@ -129,11 +129,11 @@ func TestHighlightLine_CacheHit(t *testing.T) {
 	clearHighlightCache()
 
 	// First call — cache miss, should highlight a Go file
-	result1, ok1 := highlightLine("package main", "main.go", nil, 0)
+	result1, ok1 := highlightLine("package main", "main.go", nil, 0, "")
 	assert.True(t, ok1)
 
 	// Second call — should return cached result
-	result2, ok2 := highlightLine("package main", "main.go", nil, 0)
+	result2, ok2 := highlightLine("package main", "main.go", nil, 0, "")
 	assert.True(t, ok2)
 	assert.Equal(t, result1, result2)
 }
@@ -143,7 +143,7 @@ func TestHighlightLine_NoColor(t *testing.T) {
 	noColor = true
 	defer func() { noColor = orig }()
 
-	result, ok := highlightLine("package main", "main.go", nil, 0)
+	result, ok := highlightLine("package main", "main.go", nil, 0, "")
 	assert.False(t, ok)
 	assert.Equal(t, "package main", result)
 }
@@ -153,7 +153,7 @@ func TestHighlightLine_UnknownExtension(t *testing.T) {
 	noColor = false
 	defer func() { noColor = orig }()
 
-	result, ok := highlightLine("some content", "file.xyzunknown", nil, 0)
+	result, ok := highlightLine("some content", "file.xyzunknown", nil, 0, "")
 	assert.False(t, ok)
 	assert.Equal(t, "some content", result)
 }
@@ -173,12 +173,12 @@ func TestHighlightLine_CacheKeyIncludesTheme(t *testing.T) {
 
 	SetTheme(ThemeCharmtoneDark, true)
 	bg1 := paletteFor(ThemeCharmtoneDark, true).addedBg
-	result1, ok1 := highlightLine("package main", "main.go", bg1, 0)
+	result1, ok1 := highlightLine("package main", "main.go", bg1, 0, "")
 	assert.True(t, ok1)
 
 	SetTheme(ThemeGithubLight, false)
 	bg2 := paletteFor(ThemeGithubLight, false).addedBg
-	result2, ok2 := highlightLine("package main", "main.go", bg2, 0)
+	result2, ok2 := highlightLine("package main", "main.go", bg2, 0, "")
 	assert.True(t, ok2)
 
 	// Different themes + backgrounds produce different ANSI output
@@ -219,9 +219,9 @@ func TestRenderDiffLine_HighlightedVsFallback(t *testing.T) {
 	line := git.Line{Type: git.LineAdded, Content: "package main", NewNum: 1}
 
 	// With a known Go file — should highlight
-	withHighlight := renderDiffLine(line, false, 80, "main.go", p, 0, "")
+	withHighlight := renderDiffLine(line, false, 80, "main.go", p, 0, "", "")
 	// With unknown extension — plain fallback
-	withoutHighlight := renderDiffLine(line, false, 80, "file.xyzunknown", p, 0, "")
+	withoutHighlight := renderDiffLine(line, false, 80, "file.xyzunknown", p, 0, "", "")
 
 	assert.NotEmpty(t, withHighlight)
 	assert.NotEmpty(t, withoutHighlight)
@@ -281,7 +281,7 @@ func TestHighlightLine_AutoThemeCommentFg(t *testing.T) {
 
 	SetTheme(ThemeAuto, true)
 
-	result, ok := highlightLine("// a comment", "main.go", nil, 0)
+	result, ok := highlightLine("// a comment", "main.go", nil, 0, "")
 	assert.True(t, ok)
 	// Should use ANSI 256 color 136 (foreground), not italic
 	assert.Contains(t, result, "38;5;136")
@@ -296,9 +296,173 @@ func TestRenderDiffLine_MarkedSkipsHighlight(t *testing.T) {
 	p := paletteFor(ThemeCharmtoneDark, true)
 	line := git.Line{Type: git.LineAdded, Content: "package main", NewNum: 1}
 
-	marked := renderDiffLine(line, true, 80, "main.go", p, 0, "")
-	unmarked := renderDiffLine(line, false, 80, "main.go", p, 0, "")
+	marked := renderDiffLine(line, true, 80, "main.go", p, 0, "", "")
+	unmarked := renderDiffLine(line, false, 80, "main.go", p, 0, "", "")
 
 	// Marked lines use mark styles, not syntax highlight styles — they differ
 	assert.NotEqual(t, marked, unmarked)
+}
+
+func TestCodeFenceLang(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantFence bool
+		wantLang  string
+	}{
+		{"not a fence", "regular text", false, ""},
+		{"inline code only", "use `foo` here", false, ""},
+		{"bare backtick fence", "```", true, ""},
+		{"go fence", "```go", true, "go"},
+		{"fence with space", "``` go", true, "go"},
+		{"uppercase lang", "```Go", true, "go"},
+		{"info string extra words", "```go title=main.go", true, "go"},
+		{"tilde fence", "~~~", true, ""},
+		{"tilde lang fence", "~~~python", true, "python"},
+		{"indented fence", "   ```go", true, "go"},
+		{"more than three backticks", "````go", true, "go"},
+		{"backtick in info rejected", "```foo`bar", false, ""},
+		{"empty string", "", false, ""},
+		{"two backticks not a fence", "``not", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fence, lang := codeFenceLang(tt.content)
+			assert.Equal(t, tt.wantFence, fence)
+			assert.Equal(t, tt.wantLang, lang)
+		})
+	}
+}
+
+func TestIsMarkdownFile(t *testing.T) {
+	assert.True(t, isMarkdownFile("README.md"))
+	assert.True(t, isMarkdownFile("docs/guide.markdown"))
+	assert.False(t, isMarkdownFile("main.go"))
+	assert.False(t, isMarkdownFile("file.xyzunknown"))
+}
+
+func TestLexerByName(t *testing.T) {
+	assert.NotNil(t, lexerByName("go"))
+	assert.NotNil(t, lexerByName("GO"))        // case-insensitive
+	assert.NotNil(t, lexerByName("js"))        // alias
+	assert.Nil(t, lexerByName("totallybogus")) // unknown
+	assert.Nil(t, lexerByName(""))             // empty
+}
+
+func TestHighlightLine_LangOverride(t *testing.T) {
+	orig := noColor
+	noColor = false
+	defer func() { noColor = orig }()
+	clearHighlightCache()
+
+	// A line of Go code inside a Markdown file: without an override the markdown
+	// lexer renders it as plain text; with the "go" override it's highlighted.
+	const code = "func main() {}"
+	asMarkdown, _ := highlightLine(code, "doc.md", nil, 0, "")
+	asGo, ok := highlightLine(code, "doc.md", nil, 0, "go")
+	assert.True(t, ok)
+	assert.NotEqual(t, asMarkdown, asGo, "go override should change highlighting")
+	assert.Contains(t, asGo, "\x1b[", "go override should emit ANSI styling")
+}
+
+func TestHighlightLine_LangOverrideUnknown(t *testing.T) {
+	orig := noColor
+	noColor = false
+	defer func() { noColor = orig }()
+
+	// Unknown language → no lexer → plain fallback.
+	result, ok := highlightLine("some code", "doc.md", nil, 0, "totallybogus")
+	assert.False(t, ok)
+	assert.Equal(t, "some code", result)
+}
+
+func TestHighlightLine_LangOverrideInCacheKey(t *testing.T) {
+	orig := noColor
+	noColor = false
+	defer func() { noColor = orig }()
+	clearHighlightCache()
+
+	// Same content + file but different overrides must not collide in the cache.
+	plain, _ := highlightLine("x = 1", "doc.md", nil, 0, "")
+	asPython, _ := highlightLine("x = 1", "doc.md", nil, 0, "python")
+	assert.NotEqual(t, plain, asPython)
+
+	// Re-fetching returns the per-override cached value, not a collision.
+	plainAgain, _ := highlightLine("x = 1", "doc.md", nil, 0, "")
+	assert.Equal(t, plain, plainAgain)
+}
+
+func TestHighlightLine_MarkdownHeadingBold(t *testing.T) {
+	orig := noColor
+	noColor = false
+	origTheme := activeTheme
+	origIsDark := activeIsDark
+	defer func() {
+		noColor = orig
+		activeTheme = origTheme
+		activeIsDark = origIsDark
+	}()
+
+	// Headings must render bold (ANSI code 1) across both a custom-entry theme
+	// and a named-style theme ("github") that doesn't bold headings itself.
+	for _, tc := range []struct {
+		theme Theme
+		dark  bool
+	}{
+		{ThemeGithubDark, true},   // custom entries
+		{ThemeGithubLight, false}, // named "github" style
+	} {
+		clearHighlightCache()
+		SetTheme(tc.theme, tc.dark)
+		result, ok := highlightLine("# Title", "doc.md", nil, 0, "")
+		assert.True(t, ok, "theme %s", tc.theme)
+		assert.Contains(t, result, "\x1b[1", "heading should be bold for theme %s", tc.theme)
+	}
+}
+
+func TestBuildLines_MarkdownFenceStateMachine(t *testing.T) {
+	orig := noColor
+	noColor = false
+	origTheme := activeTheme
+	origIsDark := activeIsDark
+	defer func() {
+		noColor = orig
+		activeTheme = origTheme
+		activeIsDark = origIsDark
+	}()
+	SetTheme(ThemeGithubDark, true)
+
+	dv := diffViewModel{
+		width: 80,
+		file: &git.FileDiff{
+			Path: "doc.md",
+			Hunks: makeHunks(
+				"# Heading",
+				"",
+				"```go",
+				"func main() {}",
+				"```",
+				"func main() {}", // identical text, but outside the fence
+			),
+		},
+	}
+	dv.buildLines()
+
+	// The code line inside the fence and the identical prose line outside it
+	// must render differently: inside uses the Go lexer, outside uses Markdown.
+	var rendered []string
+	for i, ref := range dv.lineRefs {
+		if ref != nil && ref.content == "func main() {}" {
+			rendered = append(rendered, dv.lines[i])
+		}
+	}
+	assert.Len(t, rendered, 2, "both occurrences should be present")
+	assert.NotEqual(t, rendered[0], rendered[1],
+		"fenced code should be highlighted as Go, prose as Markdown")
+
+	// And the fenced line should match a direct Go-override render.
+	p := paletteFor(activeTheme, activeIsDark)
+	goLine := git.Line{Type: git.LineContext, Content: "func main() {}"}
+	wantGo := renderDiffLine(goLine, false, dv.width-3, "doc.md", p, 0, "", "go")
+	assert.Equal(t, wantGo, rendered[0], "fenced line should use the go override")
 }

--- a/internal/ui/syntax_test.go
+++ b/internal/ui/syntax_test.go
@@ -403,20 +403,25 @@ func TestHighlightLine_MarkdownHeadingBold(t *testing.T) {
 		activeIsDark = origIsDark
 	}()
 
-	// Headings must render bold (ANSI code 1) across both a custom-entry theme
-	// and a named-style theme ("github") that doesn't bold headings itself.
+	// Headings must render bold (ANSI code 1) but never underline (ANSI code 4)
+	// across custom-entry themes, named-style themes ("github"), and the auto
+	// theme's "native" style — which underlines heading tokens by default.
 	for _, tc := range []struct {
 		theme Theme
 		dark  bool
 	}{
 		{ThemeGithubDark, true},   // custom entries
 		{ThemeGithubLight, false}, // named "github" style
+		{ThemeAuto, true},         // "native" style (underlines headings)
 	} {
-		clearHighlightCache()
-		SetTheme(tc.theme, tc.dark)
-		result, ok := highlightLine("# Title", "doc.md", nil, 0, "")
-		assert.True(t, ok, "theme %s", tc.theme)
-		assert.Contains(t, result, "\x1b[1", "heading should be bold for theme %s", tc.theme)
+		for _, heading := range []string{"# Title", "## Subtitle"} {
+			clearHighlightCache()
+			SetTheme(tc.theme, tc.dark)
+			result, ok := highlightLine(heading, "doc.md", nil, 0, "")
+			assert.True(t, ok, "theme %s heading %q", tc.theme, heading)
+			assert.Contains(t, result, "\x1b[1", "heading %q should be bold for theme %s", heading, tc.theme)
+			assert.NotContains(t, result, "\x1b[4m", "heading %q should not be underlined for theme %s", heading, tc.theme)
+		}
 	}
 }
 

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -105,7 +105,8 @@ func charmtoneDarkChromaEntries(daltonized bool) chroma.StyleEntries {
 		chroma.LiteralStringEscape: "#68FFD6", // Bok
 		chroma.GenericEmph:         "italic",
 		chroma.GenericStrong:       "bold",
-		chroma.GenericSubheading:   "#858392", // Squid
+		chroma.GenericHeading:      "bold #F1EFEF", // bright Salt
+		chroma.GenericSubheading:   "bold #858392", // Squid
 	}
 	if daltonized {
 		entries[chroma.NameFunction] = "#4FBEFE"    // Sardine (blue)
@@ -146,7 +147,8 @@ func githubDarkChromaEntries(daltonized bool) chroma.StyleEntries {
 		chroma.LiteralStringEscape: "bold #79c0ff",
 		chroma.GenericEmph:         "italic",
 		chroma.GenericStrong:       "bold",
-		chroma.GenericSubheading:   "#8b949e",
+		chroma.GenericHeading:      "bold #c9d1d9",
+		chroma.GenericSubheading:   "bold #8b949e",
 	}
 	if daltonized {
 		entries[chroma.GenericInserted] = "#58a6ff" // blue
@@ -183,6 +185,7 @@ func githubLightDaltonizedChromaEntries() chroma.StyleEntries {
 		chroma.LiteralStringEscape: "bold #032f62",
 		chroma.GenericDeleted:      "#b31d28",
 		chroma.GenericEmph:         "italic",
+		chroma.GenericHeading:      "bold #24292e",
 		chroma.GenericInserted:     "#005cc5", // blue instead of green
 		chroma.GenericStrong:       "bold",
 		chroma.GenericSubheading:   "bold #6a737d",


### PR DESCRIPTION
## Summary

Closes #194.

Reviewing a Markdown doc (`revise doc.md`) already rendered inline `**bold**` and `` `code` ``, but headings and fenced code blocks were left plain. This adds both:

- **Headings** now render in **bold** (and a theme color in custom dark themes), for `#` through `######`.
- **Fenced code blocks** (```` ```go ````, `~~~python`, GFM) now syntax-highlight their contents using the declared language. Bare/language-less fences and the fence delimiters themselves stay plain.

Works in both file review mode and git diff mode.

## How it works

Highlighting stays line-by-line (so it composes with per-line diff backgrounds and the per-line cache), with two Markdown-specific additions:

- **Headings**: chroma only emits `Generic.Heading`/`Generic.Subheading` when a line ends in a newline, so `highlightLine` appends one before tokenising (the formatter trims and skips the resulting empty token). Heading tokens are force-bolded in the formatter so they stand out even under named chroma styles (e.g. `github`, used for light themes) that don't bold them; custom themes also give headings a color in `theme.go`.
- **Fenced code**: `buildLines` runs a per-hunk fence state machine (`codeFenceLang` detects ```` ``` ````/`~~~` open/close + the info-string language). Lines inside a fence are highlighted with the declared language via a `langOverride` param threaded through `renderDiffLine` → `highlightLine` (`lexerByName` — case-insensitive, alias-aware). `langOverride` is part of the highlight cache key so it can't collide with the same text rendered as prose. Fence state resets per hunk, since a diff's hidden gaps make cross-hunk tracking unreliable.

## Testing

- New unit tests: `codeFenceLang` (table-driven), `isMarkdownFile`, `lexerByName`, `highlightLine` with `langOverride` + cache-key isolation, heading-bold across a custom-entry theme and a named-style theme, and a `buildLines` integration test asserting fenced code is highlighted as Go while identical prose stays Markdown.
- `make` (lint + full test suite) passes.
- Manually verified in a real terminal against a sample doc with Go/Python/bare fences and h1–h3 headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown headings now render in bold for improved readability
  * Fenced code blocks in Markdown are syntax-highlighted based on declared language in both diff and file review modes

* **Tests**
  * Added comprehensive test coverage for Markdown rendering and syntax highlighting features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->