### PR TITLE
Show a scrollbar on the diff view's right border (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- The diff view now shows a scrollbar on the right border when content overflows the viewport: the thumb's size reflects how much of the file is visible and its position shows where you are. It appears only when there's something to scroll, so short files stay uncluttered. Useful for keeping your bearings when reviewing long files, e.g. plans via `revise plan.md`. Works in both git diff and file review mode (#196)
+
 ## [0.5.1] - 2026-06-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,4 +252,11 @@ The display-row math lives in a few primitives in `diffview.go`:
 
 `clickToAbsIdx` and `scrollForCommentInput` go through the same primitives, so mouse clicks and the inline comment box stay correct with wrap on. Horizontal scroll is disabled (hOffset forced to 0) while wrapping.
 
+### Scrollbar
+
+When diff-view content overflows the viewport, a scrollbar thumb is drawn on the right border (suppressed when everything fits, so short files stay clean and existing border snapshots are unaffected). Design (#196):
+
+- `overlayScrollbar` replaces the rightmost column (the `│` border char) of the thumb's track rows with a solid `█` block, after all border-title/footer decoration is done (those only touch the top/bottom lines, never the interior right border). A full block — rather than a heavy line like `┃`, which some fonts render indistinguishably from the `│` track — makes the thumb stand out. It's `Bold` and colored `colorCyan` when the pane is focused, else `colorScrollbarThumb` (`p.dim`, a mid gray brighter than the border).
+- Geometry comes from `scrollMetrics()` (total display rows, rows above the viewport, viewport height). Row-based (not logical-line-based) math keeps it correct with soft wrap on. `scrollbarThumb` returns `(top, size, show)` with `size ≈ viewH²/totalRows` clamped to `[1, viewH-1]`; `top` is offset-based so the thumb tracks the viewport, not the cursor.
+
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"unicode"
 
@@ -631,6 +632,91 @@ func (m *diffViewModel) viewHeight() int {
 	return h
 }
 
+// scrollMetrics returns the total display rows of all content, the display rows
+// above the current viewport top (offset), and the viewport height in rows.
+// The scrollbar thumb and the scroll-position label both derive from these so
+// they always agree. Row counts (not logical-line counts) make the math correct
+// when soft wrap is on.
+func (m diffViewModel) scrollMetrics() (totalRows, rowsAbove, viewH int) {
+	viewH = m.viewHeight()
+	if len(m.lines) == 0 {
+		return 0, 0, viewH
+	}
+	avail := m.viewWidth()
+	totalRows = m.rowSpan(0, len(m.lines)-1, avail)
+	if m.offset > 0 {
+		rowsAbove = m.rowSpan(0, m.offset-1, avail)
+	}
+	return totalRows, rowsAbove, viewH
+}
+
+// scrollbarThumb returns the thumb's top row and size within the viewport track
+// (viewH rows) and whether to draw it. show is false when all content fits or
+// the viewport is too short to render a meaningful thumb.
+func (m diffViewModel) scrollbarThumb() (top, size int, show bool) {
+	totalRows, rowsAbove, viewH := m.scrollMetrics()
+	if viewH < 2 || totalRows <= viewH {
+		return 0, 0, false
+	}
+	size = int(math.Round(float64(viewH) * float64(viewH) / float64(totalRows)))
+	if size < 1 {
+		size = 1
+	}
+	if size > viewH-1 {
+		size = viewH - 1 // leave at least one row of travel so the thumb can move
+	}
+	maxAbove := totalRows - viewH
+	maxTop := viewH - size
+	frac := 0.0
+	if maxAbove > 0 {
+		frac = float64(rowsAbove) / float64(maxAbove)
+	}
+	frac = math.Min(1, math.Max(0, frac))
+	top = int(math.Round(float64(maxTop) * frac))
+	if top < 0 {
+		top = 0
+	}
+	if top > maxTop {
+		top = maxTop
+	}
+	return top, size, true
+}
+
+// overlayScrollbar draws the scrollbar thumb onto the right border of an
+// already-rendered, bordered box by replacing the rightmost column of the
+// thumb's track rows with a solid block. A full block (rather than a heavy line
+// like ┃, which some fonts render indistinguishably from the │ track) makes the
+// thumb stand out, and it's colored cyan when the pane is focused. No-op when
+// all content fits. Interior rows are lines[1 .. len-2]; track row t → lines[t+1].
+func (m diffViewModel) overlayScrollbar(rendered string, focused bool) string {
+	top, size, show := m.scrollbarThumb()
+	if !show || size <= 0 {
+		return rendered
+	}
+	lines := strings.Split(rendered, "\n")
+	if len(lines) < 3 {
+		return rendered // need a top border, ≥1 interior row, and a bottom border
+	}
+	interior := len(lines) - 2
+
+	thumbColor := colorScrollbarThumb
+	if focused {
+		thumbColor = colorCyan
+	}
+	thumb := lipgloss.NewStyle().Foreground(thumbColor).Bold(true).Render("█")
+
+	for t := top; t < top+size && t < interior; t++ {
+		rowIdx := t + 1
+		line := lines[rowIdx]
+		w := ansi.StringWidth(line)
+		if w < 1 {
+			continue
+		}
+		lines[rowIdx] = ansi.Truncate(line, w-1, "") + thumb
+	}
+	return strings.Join(lines, "\n")
+}
+
 // matchRanges returns the rune-index ranges of every case-insensitive
 // occurrence of query within content. Ranges are [start, end) in runes so
 // callers can slice []rune(content) directly. Returns nil for an empty query
@@ -1178,7 +1264,7 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 		if m.wrapEnabled {
 			rendered = setBorderBottomRight(rendered, modeActiveStyle.Render(" Wrap "), focused)
 		}
-		return rendered
+		return m.overlayScrollbar(rendered, focused)
 	}
 
 	title := ""
@@ -1218,7 +1304,7 @@ func (m diffViewModel) render(focused bool, contextLines int, hideWhitespace boo
 		right += statusBarStyle.Render(" Whitespace ")
 	}
 	rendered = setBorderBottomRight(rendered, right, focused)
-	return rendered
+	return m.overlayScrollbar(rendered, focused)
 }
 
 // setBorderTitle overlays a styled title onto the top border of a lipgloss-rendered box.

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -732,3 +732,41 @@ func TestSetBorderBottomCounts_NarrowPaneFallback(t *testing.T) {
 	// Should not panic and should produce a valid string
 	assert.NotEmpty(t, result)
 }
+
+func TestScrollbarThumb_HiddenWhenContentFits(t *testing.T) {
+	m := makeDiffViewModel(5, 10)
+	_, _, show := m.scrollbarThumb()
+	assert.False(t, show)
+}
+
+func TestScrollbarThumb_PositionAndSize(t *testing.T) {
+	// 100 lines, 10-row viewport: thumb size ≈ viewH*viewH/total = 1.
+	m := makeDiffViewModel(100, 10)
+
+	m.offset = 0
+	top, size, show := m.scrollbarThumb()
+	assert.True(t, show)
+	assert.Equal(t, 0, top, "thumb sits at the top when offset is 0")
+	assert.GreaterOrEqual(t, size, 1)
+	assert.Less(t, size, 10, "thumb is smaller than the track for a long file")
+
+	// At the bottom, the thumb sits flush against the end of the track.
+	m.offset = m.bottomOffset()
+	topB, sizeB, _ := m.scrollbarThumb()
+	assert.Equal(t, 10-sizeB, topB, "thumb sits at the bottom of the track")
+}
+
+func TestDiffViewRender_ScrollbarThumbVisibility(t *testing.T) {
+	// Long content draws a thumb glyph on the right border.
+	long := makeDiffViewModel(100, 10)
+	long.width = 40
+	long.offset = 0
+	out := ansi.Strip(long.render(true, 3, false))
+	assert.Contains(t, out, "█", "long content should draw a scrollbar thumb")
+
+	// Short content (fits the viewport) draws no thumb.
+	short := makeDiffViewModel(3, 10)
+	short.width = 40
+	shortOut := ansi.Strip(short.render(true, 3, false))
+	assert.NotContains(t, shortOut, "█", "short content should not draw a scrollbar")
+}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -18,6 +18,10 @@ var (
 	colorBorder color.Color = lipgloss.Color("#374151")
 	colorCyan   color.Color = lipgloss.Color("#06b6d4")
 	colorYellow color.Color = lipgloss.Color("#eab308")
+	// colorScrollbarThumb is the right-border scrollbar thumb color when the
+	// diff pane is unfocused — a mid gray, brighter than colorBorder so the
+	// thumb stands out from the border track. Focused panes use colorCyan.
+	colorScrollbarThumb color.Color = lipgloss.Color("#6b7280")
 )
 
 // SetTheme sets the active theme. Called from main.go for --theme overrides,
@@ -131,6 +135,7 @@ func applyTheme(p themeColors) {
 	colorBorder = p.border
 	colorCyan = p.cyan
 	colorYellow = p.yellow
+	colorScrollbarThumb = p.dim
 
 	addedStyle = lipgloss.NewStyle().Foreground(p.addedFg).Background(p.addedBg)
 	removedStyle = lipgloss.NewStyle().Foreground(p.removedFg).Background(p.removedBg)


### PR DESCRIPTION
Closes #196.

When reviewing longer files (e.g. plans via `revise plan.md`) there was no indication of where you are in the file or how long it is. This adds a scrollbar thumb on the diff view's right border:

- The thumb's **size** reflects how much of the file is visible; its **position** shows where you are.
- Appears **only when content overflows** the viewport, so short files stay uncluttered.
- Works in both git diff and file review mode.

The thumb is a solid block (`█`) — `colorCyan` when the pane is focused, a mid-gray (`p.dim`) when not. A full block reads unambiguously even in fonts where a heavy line (`┃`) can look identical to the `│` track.

```
│    18 line 18 content here               │
│    19 line 19 content here               █
│    20 line 20 content here               █
│    21 line 21 content here               █
│    22 line 22 content here               │
╰──────────────────────────────────────────╯
```

## Implementation
- `scrollMetrics()` → total display rows, rows above viewport, viewport height (row-based, so it's correct with soft wrap on).
- `scrollbarThumb()` → `(top, size, show)`; `size ≈ viewH²/totalRows` clamped to `[1, viewH-1]`, `top` offset-based (tracks the viewport).
- `overlayScrollbar()` replaces the rightmost border column of the thumb's track rows, after border-title/footer decoration (which only touches top/bottom lines).

## Tests
- Unit tests for thumb visibility, size, and position.
- Render test asserting the thumb glyph appears for long content and not for short.
- `make` green (lint + all tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scrollbar to the diff viewer that appears when content overflows. The scrollbar thumb indicates your scroll position and coverage of visible content, working in both git diff and file review modes.

* **Documentation**
  * Updated release notes and technical documentation for the new diff viewer scrollbar feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->