### PR TITLE
Adapt the auto theme to light terminals (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The `auto` theme now adapts diff-line backgrounds to a light terminal. Previously, on a light background, added/removed lines kept a hardcoded dark background, so the (dark) syntax-highlight text was baked over it and became unreadable. Auto mode on a light terminal now mirrors the `github-light` palette, and the daltonized auto theme picks up the colorblind-safe light syntax colors too (#198)
+
 ## [0.5.2] - 2026-06-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ Four modes: ModeBranch (broadest), ModeStaged, ModeStagedOnly, ModeUnstaged (nar
 - Focused panel gets cyan border; unfocused gets dim border
 - Help overlay uses yellow border to distinguish from panels
 - Lipgloss `Width(n)`/`Height(n)` include padding but exclude borders — when setting explicit dimensions, add padding to the content size
+- `theme.go` resolves a `themeColors` palette per theme. The `auto`/`auto-daltonized` themes consult `isDark` (detected via `lipgloss.HasDarkBackground`): on a dark terminal they use ANSI named colors to adopt the terminal's palette, but on a light terminal those (notably white/yellow) are illegible, so `autoPalette`/`autoDaltonizedPalette` mirror the curated `github-light` palettes. Diff-line backgrounds are baked into syntax-highlight tokens, so a dark `addedBg`/`removedBg` on a light terminal makes the dark highlight text unreadable — this is why the palette must follow `isDark` (#198). `ThemeAutoDaltonized` therefore also appears in `chromaStyleEntries` (it only reaches there on a light terminal; dark selects the `native` chroma style first in `highlightLine`).
 
 ### Syntax Highlighting
 

--- a/internal/ui/syntax.go
+++ b/internal/ui/syntax.go
@@ -135,17 +135,18 @@ func highlightLine(content, filePath string, bg color.Color, indentSize int, lan
 
 	var style *chroma.Style
 	isAuto := theme == ThemeAuto || theme == ThemeAutoDaltonized
-	if isAuto {
-		// Auto themes use a built-in chroma style that works with the
-		// terminal's native palette instead of hardcoded hex colors.
-		if isDark {
-			style = styles.Get("native")
-		} else {
-			style = styles.Get(chromaStyleFor())
-		}
-	} else if entries := chromaStyleEntries(theme); entries != nil {
+	entries := chromaStyleEntries(theme)
+	switch {
+	case isAuto && isDark:
+		// Dark terminal: a built-in chroma style that works with the terminal's
+		// native palette instead of hardcoded hex colors.
+		style = styles.Get("native")
+	case entries != nil:
+		// Custom per-theme token colors (includes auto + light + daltonized,
+		// which needs the green→blue swap).
 		style = chroma.MustNewStyle("revise", entries)
-	} else {
+	default:
+		// Light terminal / named light themes: the github chroma style.
 		style = styles.Get(chromaStyleFor())
 	}
 

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -73,7 +73,9 @@ func chromaStyleEntries(t Theme) chroma.StyleEntries {
 		return charmtoneDarkChromaEntries(t == ThemeCharmtoneDarkDaltonized)
 	case ThemeGithubDark, ThemeGithubDarkDaltonized:
 		return githubDarkChromaEntries(t == ThemeGithubDarkDaltonized)
-	case ThemeGithubLightDaltonized, ThemeCharmtoneLightDaltonized:
+	case ThemeGithubLightDaltonized, ThemeCharmtoneLightDaltonized, ThemeAutoDaltonized:
+		// ThemeAutoDaltonized only reaches here on a light terminal; on a dark
+		// terminal highlightLine selects the "native" chroma style first.
 		return githubLightDaltonizedChromaEntries()
 	default:
 		return nil // use named style
@@ -237,13 +239,21 @@ func paletteFor(t Theme, isDark bool) themeColors {
 	case ThemeGithubLightDaltonized:
 		return githubLightDaltonizedPalette()
 	case ThemeAutoDaltonized:
-		return autoDaltonizedPalette()
+		return autoDaltonizedPalette(isDark)
 	default: // ThemeAuto
-		return autoPalette()
+		return autoPalette(isDark)
 	}
 }
 
-func autoPalette() themeColors {
+// autoPalette returns the palette for ThemeAuto. On a dark terminal it uses
+// ANSI named colors so it adopts the terminal's own palette; on a light
+// terminal it mirrors the curated github-light palette, because ANSI colors
+// (notably yellow and white) are illegible on a light background and the
+// auto-light syntax highlighter already uses the github chroma style (#198).
+func autoPalette(isDark bool) themeColors {
+	if !isDark {
+		return githubLightPalette()
+	}
 	return themeColors{
 		addedFg:         lipgloss.Green,
 		removedFg:       lipgloss.Red,
@@ -264,8 +274,11 @@ func autoPalette() themeColors {
 	}
 }
 
-func autoDaltonizedPalette() themeColors {
-	p := autoPalette()
+func autoDaltonizedPalette(isDark bool) themeColors {
+	if !isDark {
+		return githubLightDaltonizedPalette()
+	}
+	p := autoPalette(true)
 	p.addedFg = lipgloss.Blue
 	p.addedBg = lipgloss.Color("#1a1f2e")
 	p.gutterAddedFg = lipgloss.Color("27") // ANSI 256: muted blue

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"fmt"
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// luminance returns the perceived relative luminance of c on a 0 (black) to 1
+// (white) scale.
+func luminance(c color.Color) float64 {
+	r, g, b, _ := c.RGBA() // each channel is 0..65535
+	return (0.299*float64(r) + 0.587*float64(g) + 0.114*float64(b)) / 65535.0
+}
+
+// TestAutoPalette_AdaptsToTerminalBackground guards against #198: on a light
+// terminal the auto theme must use light diff-line backgrounds, otherwise dark
+// syntax-highlight foregrounds are baked over a dark background and become
+// unreadable ("code bg is always dark").
+func TestAutoPalette_AdaptsToTerminalBackground(t *testing.T) {
+	dark := paletteFor(ThemeAuto, true)
+	light := paletteFor(ThemeAuto, false)
+
+	// Dark terminal: diff backgrounds are dark.
+	assert.Less(t, luminance(dark.addedBg), 0.5, "auto dark addedBg should be dark")
+	assert.Less(t, luminance(dark.removedBg), 0.5, "auto dark removedBg should be dark")
+
+	// Light terminal: diff backgrounds must be light.
+	assert.Greater(t, luminance(light.addedBg), 0.5, "auto light addedBg should be light")
+	assert.Greater(t, luminance(light.removedBg), 0.5, "auto light removedBg should be light")
+
+	// The prominent foreground must be dark on a light terminal so file names,
+	// the selected row, and help text stay readable.
+	assert.Less(t, luminance(light.white), 0.5, "auto light prominent fg should be dark")
+}
+
+func TestAutoDaltonizedPalette_AdaptsToTerminalBackground(t *testing.T) {
+	dark := paletteFor(ThemeAutoDaltonized, true)
+	light := paletteFor(ThemeAutoDaltonized, false)
+
+	assert.Less(t, luminance(dark.addedBg), 0.5, "auto-daltonized dark addedBg should be dark")
+	assert.Greater(t, luminance(light.addedBg), 0.5, "auto-daltonized light addedBg should be light")
+	assert.Greater(t, luminance(light.removedBg), 0.5, "auto-daltonized light removedBg should be light")
+	assert.Less(t, luminance(light.white), 0.5, "auto-daltonized light prominent fg should be dark")
+}
+
+// TestHighlightLine_AutoLightIsReadable verifies the auto theme bakes a light
+// background behind syntax highlighting on a light terminal (#198).
+func TestHighlightLine_AutoLightIsReadable(t *testing.T) {
+	orig := noColor
+	noColor = false
+	origTheme := activeTheme
+	origIsDark := activeIsDark
+	defer func() {
+		noColor = orig
+		SetTheme(origTheme, origIsDark)
+	}()
+
+	SetTheme(ThemeAuto, false)
+	bg := paletteFor(ThemeAuto, false).addedBg
+	out, ok := highlightLine("package main", "main.go", bg, 0, "")
+	assert.True(t, ok)
+
+	// The dark added background from the dark palette must not appear.
+	darkBg := paletteFor(ThemeAuto, true).addedBg
+	dr, dg, db, _ := darkBg.RGBA()
+	assert.NotContains(t, out, sgrBg(dr, dg, db), "auto light must not bake the dark added background")
+}
+
+// sgrBg builds the truecolor background SGR parameter fragment lipgloss emits
+// for an RGB color (channels are 0..65535 from color.Color, shifted to 0..255).
+func sgrBg(r, g, b uint32) string {
+	return fmt.Sprintf("48;2;%d;%d;%d", r>>8, g>>8, b>>8)
+}


### PR DESCRIPTION
Fixes #198.

## Problem

On a light terminal, the default `auto` theme rendered syntax-highlighted diff lines with a **dark code background**, making the (dark) highlight text unreadable.

`paletteFor`'s doc comment promised `isDark` was consulted for the auto themes, but `autoPalette`/`autoDaltonizedPalette` ignored it entirely — they always returned a hardcoded dark `addedBg`/`removedBg` (`#1a2e1f` / `#2e1a1c`). Since the diff-line background is baked into every syntax-highlight token, the github-light foreground (dark text) ended up on a dark background:

```
before (auto + light terminal): "\x1b[38;2;207;34;46;48;2;26;46;31mfunc…"   ← dark text on #1a2e1f
after:                          "\x1b[38;2;207;34;46;48;2;209;250;229mfunc…" ← dark text on #d1fae5
```

Explicit light themes (`github-light`, `charmtone-light`) were already correct; only `auto` on a light terminal was broken.

## Fix

- `autoPalette`/`autoDaltonizedPalette` now take `isDark` and mirror the curated `github-light` / `github-light-daltonized` palettes on a light terminal. ANSI named colors (used on dark to adopt the terminal palette) are illegible on a light background — notably white and yellow — so a curated light palette is the right call, and auto-light already used the `github` chroma style for syntax.
- `highlightLine` selects the matching light chroma style on a light terminal, including the colorblind-safe green→blue swap for `auto-daltonized` (previously it fell back to the non-daltonized `github` style on light).

## Tests

- `TestAutoPalette_AdaptsToTerminalBackground` / `TestAutoDaltonizedPalette_AdaptsToTerminalBackground` — diff backgrounds are dark on a dark terminal and light on a light terminal; prominent foreground is dark on light.
- `TestHighlightLine_AutoLightIsReadable` — auto-light no longer bakes the dark added background into highlighted output.

`make` (lint + full suite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto theme to intelligently adjust diff-line background colors based on terminal type, ensuring readable highlighting on light terminals.
  * Fixed daltonized auto theme to properly apply colorblind-safe light syntax colors on light terminals.

* **Tests**
  * Added comprehensive tests verifying correct theme adaptation to terminal background darkness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->